### PR TITLE
Fix AES key derivation for encryption / decryption

### DIFF
--- a/accounts/src/key_management/ephemeral_key_holder.rs
+++ b/accounts/src/key_management/ephemeral_key_holder.rs
@@ -1,4 +1,4 @@
-use aes_gcm::{aead::Aead, AeadCore, Aes256Gcm, Key, KeyInit};
+use aes_gcm::{aead::Aead, AeadCore, Aes256Gcm, KeyInit};
 use elliptic_curve::point::AffineCoordinates;
 use elliptic_curve::PrimeField;
 use k256::{AffinePoint, FieldBytes, Scalar};


### PR DESCRIPTION
The key used for AES encryption and decryption is being computed as 
```rust
let binding = serde_json::to_vec(&key_point).unwrap();
let key_raw = &binding.as_slice()[..32];
let key_raw_adjust: [u8; 32] = key_raw.try_into().unwrap();

let key: Key<Aes256Gcm> = key_raw_adjust.into();
```
This does not effectively set the x coordinate of the shared secret point as the key for AES. The problem is in the json serialization of the point. The value of the `binding` variable is the ascii representaition of the string `"02` or `"03` (depending on the parity of the y coordinate), followed by the ascii bytes of the hex string representation of the 32 bytes of the x coordinate of the point, which are 64 characters. Therefore, defining `key_raw` as above will miss more than the half of the bytes in the ascii representation of the shared secret.

This PR proposes a fix to this by using the methods provided by the implementation of the `elliptic_curve::point::AffineCoordinates` trait of the `AffinePoint` struct.