### PR TITLE
Bump risc0 version to 2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "bonsai-sdk"
 version = "1.4.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "duplicate",
  "maybe-async",
@@ -3715,8 +3715,8 @@ checksum = "3df6368f71f205ff9c33c076d170dd56ebf68e8161c733c0caa07a7a5509ed53"
 
 [[package]]
 name = "risc0-binfmt"
-version = "2.0.1"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.0.2"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "borsh",
@@ -3733,8 +3733,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-build"
-version = "2.1.2"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.2.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "cargo_metadata",
@@ -3757,7 +3757,7 @@ dependencies = [
 [[package]]
 name = "risc0-build-kernel"
 version = "2.0.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "cc",
  "directories",
@@ -3770,8 +3770,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak"
-version = "2.0.2"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3791,8 +3791,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-keccak-sys"
-version = "2.0.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "cc",
  "cust",
@@ -3806,8 +3806,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion"
-version = "2.0.2"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "bytemuck",
@@ -3831,8 +3831,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-recursion-sys"
-version = "2.0.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "glob",
  "risc0-build-kernel",
@@ -3843,8 +3843,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im"
-version = "2.0.4"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "auto_ops",
@@ -3874,8 +3874,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-circuit-rv32im-sys"
-version = "2.0.2"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "3.0.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "cc",
  "cust",
@@ -3890,7 +3890,7 @@ dependencies = [
 [[package]]
 name = "risc0-core"
 version = "2.0.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "bytemuck",
  "bytemuck_derive",
@@ -3901,8 +3901,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-groth16"
-version = "2.0.1"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.0.2"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "ark-bn254",
@@ -3926,7 +3926,7 @@ dependencies = [
 [[package]]
 name = "risc0-sys"
 version = "1.4.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "cust",
@@ -3937,7 +3937,7 @@ dependencies = [
 [[package]]
 name = "risc0-zkos-v1compat"
 version = "2.0.1"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "include_bytes_aligned",
  "no_std_strings",
@@ -3945,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkp"
-version = "2.0.1"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.0.2"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "anyhow",
  "blake2",
@@ -3976,8 +3976,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm"
-version = "2.1.0"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.2.0"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -4022,8 +4022,8 @@ dependencies = [
 
 [[package]]
 name = "risc0-zkvm-platform"
-version = "2.0.2"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+version = "2.0.3"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "bytemuck",
  "cfg-if",
@@ -4185,7 +4185,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "rzup"
 version = "0.4.1"
-source = "git+https://github.com/risc0/risc0.git?branch=release-2.1#f34d6913945ab9f214219f3cbee1703f63936cc4"
+source = "git+https://github.com/risc0/risc0.git?branch=release-2.2#eff3c74bf9992401c2c68bea95eb6c93b27999ec"
 dependencies = [
  "semver",
  "serde",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -9,7 +9,7 @@ thiserror.workspace = true
 serde_json.workspace = true
 serde.workspace = true
 reqwest.workspace = true
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.1" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.2" }
 
 rs_merkle.workspace = true
 sha2.workspace = true

--- a/node_core/Cargo.toml
+++ b/node_core/Cargo.toml
@@ -18,7 +18,7 @@ reqwest.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tempfile.workspace = true
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.1" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.2" }
 hex.workspace = true
 actix-rt.workspace = true
 

--- a/sc_core/Cargo.toml
+++ b/sc_core/Cargo.toml
@@ -19,7 +19,7 @@ light-poseidon.workspace = true
 ark-bn254.workspace = true
 ark-ff.workspace = true
 
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.1" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.2" }
 
 [dependencies.accounts]
 path = "../accounts"

--- a/zkvm/Cargo.toml
+++ b/zkvm/Cargo.toml
@@ -12,7 +12,7 @@ serde.workspace = true
 thiserror.workspace = true
 rand.workspace = true
 
-risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.1" }
+risc0-zkvm = { git = "https://github.com/risc0/risc0.git", branch = "release-2.2" }
 test-methods = { path = "test_methods" }
 
 [dependencies.accounts]

--- a/zkvm/test_methods/Cargo.toml
+++ b/zkvm/test_methods/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [build-dependencies]
-risc0-build = { git = "https://github.com/risc0/risc0.git", branch = "release-2.1" }
+risc0-build = { git = "https://github.com/risc0/risc0.git", branch = "release-2.2" }
 
 [package.metadata.risc0]
 methods = ["guest"]


### PR DESCRIPTION
## 🎯 Purpose

*What problem does this PR solve or what feature does it add? Mention issues related to it*

This PR bumps risc0 version to 2.2. Since our CI doesn't pin the version yet, recent updates to r0 broke our CI.

## ⚙️ Approach

*Describe the core changes introduced by this PR.*

Changed risc0 version from `2.1` to `2.2` in the relevant `Cargo.toml` files. For ex:

https://github.com/vacp2p/nescience-testnet/blob/1d4548fb3b412471d7b72f4a8c6d4c56554d6cdb/common/Cargo.toml#L12


## 🧪 How to Test

*How to verify that this PR works as intended.*

Check that CI jobs succeed.

## 🔗 Dependencies

*Link PRs that must be merged before this one.*

None

## 🔜 Future Work

*List any work intentionally left out of this PR, whether due to scope, prioritization, or pending decisions.*

- Pin versions of rzup in the CI so that we don't run into the same issue in the future.

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
