### PR TITLE
Add view tag computation

### DIFF
--- a/nssa/src/state.rs
+++ b/nssa/src/state.rs
@@ -801,7 +801,7 @@ pub mod tests {
         let message = Message::try_from_circuit_output(
             vec![sender_keys.address()],
             vec![sender_nonce],
-            vec![epk],
+            vec![(recipient_keys.npk(), recipient_keys.ivk(), epk)],
             output,
         )
         .unwrap();
@@ -854,8 +854,16 @@ pub mod tests {
         )
         .unwrap();
 
-        let message =
-            Message::try_from_circuit_output(vec![], vec![], vec![epk_1, epk_2], output).unwrap();
+        let message = Message::try_from_circuit_output(
+            vec![],
+            vec![],
+            vec![
+                (sender_keys.npk(), sender_keys.ivk(), epk_1),
+                (recipient_keys.npk(), recipient_keys.ivk(), epk_2),
+            ],
+            output,
+        )
+        .unwrap();
 
         let witness_set = WitnessSet::for_message(&message, proof, &[]);
 
@@ -899,9 +907,13 @@ pub mod tests {
         )
         .unwrap();
 
-        let message =
-            Message::try_from_circuit_output(vec![*recipient_address], vec![], vec![epk], output)
-                .unwrap();
+        let message = Message::try_from_circuit_output(
+            vec![*recipient_address],
+            vec![],
+            vec![(sender_keys.npk(), sender_keys.ivk(), epk)],
+            output,
+        )
+        .unwrap();
 
         let witness_set = WitnessSet::for_message(&message, proof, &[]);
 


### PR DESCRIPTION
## 🎯 Purpose

This PR adds computation of tags to privacy preserving transaction messages.

## ⚙️ Approach

- Add a method to compute tags from the nullifier public key and the incoming viewing public key.
https://github.com/vacp2p/nescience-testnet/blob/46753e37e8c1c13317ef38292137a605b7c75feb/nssa/src/privacy_preserving_transaction/message.rs#L34-L42
- Add a constructor of `EncryptedAccountData` that uses the above method to derive the corresponding tag
https://github.com/vacp2p/nescience-testnet/blob/46753e37e8c1c13317ef38292137a605b7c75feb/nssa/src/privacy_preserving_transaction/message.rs#L19-L32

## 🧪 How to Test

The following test should pass.
https://github.com/vacp2p/nescience-testnet/blob/46753e37e8c1c13317ef38292137a605b7c75feb/nssa/src/privacy_preserving_transaction/message.rs#L151

## 🔗 Dependencies

Depends on PR #103 

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
