### PR TITLE
Fix sequencer runner

### DIFF
--- a/sequencer_runner/configs/debug/sequencer_config.json
+++ b/sequencer_runner/configs/debug/sequencer_config.json
@@ -7,6 +7,13 @@
     "block_create_timeout_millis": 10000,
     "port": 3040,
     "initial_accounts": [
-        
+        {
+            "addr": "1b84c5567b126440995d3ed5aaba0565d71e1834604819ff9c17f5e9d5dd078f",
+            "balance": 10000
+        },
+        {
+            "addr": "4d4b6cd1361032ca9bd2aeb9d900aa4d45d9ead80ac9423374c451a7254d0766",
+            "balance": 20000
+        }
     ]
 }

--- a/sequencer_runner/src/lib.rs
+++ b/sequencer_runner/src/lib.rs
@@ -75,7 +75,9 @@ pub async fn main_runner() -> Result<()> {
     }
 
     //ToDo: Add restart on failures
-    let (_, _) = startup_sequencer(app_config).await?;
+    let (_, main_loop_handle) = startup_sequencer(app_config).await?;
+
+    main_loop_handle.await??;
 
     Ok(())
 }


### PR DESCRIPTION
## 🎯 Purpose

This PR is a small fix to the sequencer_runner. The problem was that the main loop was not being awaited and the process ended right after start. Also, the config was empty of accounts to test.

## ⚙️ Approach

- Await on the main loop handle to keep the process alive.
- Update the config to add the initial accounts from the integration tests.

## 🧪 How to Test

Run the sequencer with
- `cd sequencer_runner`
- Remove any old bock data with `rm -rf rocksdb`.
- `RUST_LOG=info cargo run configs/debug`
And wait to see it produce blocks

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
