### PR TITLE
Fix merge compilation error

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1410,7 +1410,7 @@ pub async fn test_program_deployment() {
     let message = nssa::program_deployment_transaction::Message::new(bytecode.clone());
     let transaction = ProgramDeploymentTransaction::new(message);
 
-    let wallet_config = fetch_config().unwrap();
+    let wallet_config = fetch_config().await.unwrap();
     let seq_client = SequencerClient::new(wallet_config.sequencer_addr.clone()).unwrap();
 
     let _response = seq_client.send_tx_program(transaction).await.unwrap();


### PR DESCRIPTION
## 🎯 Purpose

This PR fixes a compilation error after merge of two independent PRs.

## ⚙️ Approach

Add `await` to the `fetch_config` call.

## 🧪 How to Test

Run tests

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
