### PR TITLE
test_success_private_transfer_to_another_owned_account_cont_run_path test fix

### DIFF
--- a/integration_tests/src/test_suite_map.rs
+++ b/integration_tests/src/test_suite_map.rs
@@ -1185,9 +1185,20 @@ pub fn prepare_function_map() -> HashMap<String, TestFunction> {
         tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
         tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
+        let wallet_config = fetch_config().await.unwrap();
         let wallet_storage = WalletCore::start_from_config_update_chain(wallet_config)
             .await
             .unwrap();
+
+        info!("All private accounts data");
+        for (addr, (_, acc)) in &wallet_storage.storage.user_data.user_private_accounts {
+            info!("{addr} :: {acc:#?}");
+        }
+
+        let new_commitment1 = wallet_storage
+            .get_private_account_commitment(&from)
+            .unwrap();
+        assert_eq!(tx.message.new_commitments[0], new_commitment1);
 
         assert_eq!(tx.message.new_commitments.len(), 2);
         for commitment in tx.message.new_commitments.into_iter() {


### PR DESCRIPTION
## 🎯 Purpose

Fixes test `test_success_private_transfer_to_another_owned_account_cont_run_path` for CI.

## ⚙️ Approach

Test `test_success_private_transfer_to_another_owned_account_cont_run_path` behaves strangely. At least on my machine, it works on `main` and other branches, while failing on CI. 

On CI test fails to see newly created accounts, which leads to error.

It is fixed by adding additional config fetch before checks. It is not clear why it happens on CI.

- [ ] Test fix

DOES NOT WORK 

## 🧪 How to Test

Integration tests must pass.

## 🔗 Dependencies

None

## 🔜 Future Work

Investigate problem further.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
