### PR TITLE
feat: add list account subcommand

### DIFF
--- a/integration_tests/src/test_suite_map.rs
+++ b/integration_tests/src/test_suite_map.rs
@@ -1169,8 +1169,8 @@ pub fn prepare_function_map() -> HashMap<String, TestFunction> {
     // #[nssa_integration_test]
     // pub async fn test_success_private_transfer_to_another_owned_account_cont_run_path() {
     //     info!(
-    //         "########## test_success_private_transfer_to_another_owned_account_cont_run_path ##########"
-    //     );
+    //         "########## test_success_private_transfer_to_another_owned_account_cont_run_path
+    // ##########"     );
     //     let continious_run_handle = tokio::spawn(wallet::execute_continious_run());
 
     //     let from: AccountId = ACC_SENDER_PRIVATE.parse().unwrap();

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -19,6 +19,7 @@ borsh.workspace = true
 base58.workspace = true
 hex = "0.4.3"
 rand.workspace = true
+itertools = "0.14.0"
 
 [dependencies.key_protocol]
 path = "../key_protocol"


### PR DESCRIPTION
## 🎯 Purpose

Resolves:

- #185 

## ⚙️ Approach

Added `list` (with `ls` alias) command which prints all available accounts in the storage

## 🧪 How to Test

`cargo run --bin wallet -- account list`

Sample output:

```txt
Public/BLgCRDXYdQPMMWVHYRFGQZbgeHx9frkipa8GtpG2Syqy,
Public/Gj1mJy5W7J5pfmLRujmQaLfLMWidNxQ6uwnhb666ZwHw,
Private/3oCG8gqdKLMegw4rRfyaMQvuPHpcASt7xwttsmnZLSkw,
Private/AKTcXgJ1xoynta1Ec7y6Jso1z1JQtHqd7aPQ1h9er6xX
```

This works offline.

Using these accounts you can get more info about them via `account get` command.

## 🔗 Dependencies

None

## 🔜 Future Work

Non urgent but we may consider more interactive UI if we really want to. So that at first user chooses an account, then chooses what they'd like to do with it.

That will require a proper interactive tui library, not just `clap` for cmd args parsing.

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests (N/A, don't think we have to write test for this literally just `println` statement)
- [x] Add/update documentation and inline comments
