### PR TITLE
Add basic auth to wallet

### DIFF
--- a/nssa/program_methods/guest/src/bin/pinata_token.rs
+++ b/nssa/program_methods/guest/src/bin/pinata_token.rs
@@ -1,8 +1,11 @@
 use nssa_core::program::{
-    read_nssa_inputs, write_nssa_outputs_with_chained_call, AccountPostState, ChainedCall, PdaSeed, ProgramInput
+    AccountPostState, ChainedCall, PdaSeed, ProgramInput, read_nssa_inputs,
+    write_nssa_outputs_with_chained_call,
 };
-use risc0_zkvm::serde::to_vec;
-use risc0_zkvm::sha::{Impl, Sha256};
+use risc0_zkvm::{
+    serde::to_vec,
+    sha::{Impl, Sha256},
+};
 
 const PRIZE: u128 = 150;
 
@@ -46,7 +49,8 @@ impl Challenge {
 /// A pinata program
 fn main() {
     // Read input accounts.
-    // It is expected to receive three accounts: [pinata_definition, pinata_token_holding, winner_token_holding]
+    // It is expected to receive three accounts: [pinata_definition, pinata_token_holding,
+    // winner_token_holding]
     let ProgramInput {
         pre_states,
         instruction: solution,
@@ -83,7 +87,10 @@ fn main() {
     let chained_calls = vec![ChainedCall {
         program_id: pinata_token_holding_post.program_owner,
         instruction_data: to_vec(&instruction_data).unwrap(),
-        pre_states: vec![pinata_token_holding_for_chain_call, winner_token_holding.clone()],
+        pre_states: vec![
+            pinata_token_holding_for_chain_call,
+            winner_token_holding.clone(),
+        ],
         pda_seeds: vec![PdaSeed::new([0; 32])],
     }];
 

--- a/nssa/program_methods/guest/src/bin/privacy_preserving_circuit.rs
+++ b/nssa/program_methods/guest/src/bin/privacy_preserving_circuit.rs
@@ -1,15 +1,14 @@
 use std::collections::HashSet;
 
-use risc0_zkvm::{guest::env, serde::to_vec};
-
 use nssa_core::{
-    Commitment, CommitmentSetDigest, DUMMY_COMMITMENT_HASH, EncryptionScheme,
-    Nullifier, NullifierPublicKey, PrivacyPreservingCircuitInput, PrivacyPreservingCircuitOutput,
+    Commitment, CommitmentSetDigest, DUMMY_COMMITMENT_HASH, EncryptionScheme, Nullifier,
+    NullifierPublicKey, PrivacyPreservingCircuitInput, PrivacyPreservingCircuitOutput,
     account::{Account, AccountId, AccountWithMetadata},
     compute_digest_for_path,
     encryption::Ciphertext,
     program::{DEFAULT_PROGRAM_ID, ProgramOutput, validate_execution},
 };
+use risc0_zkvm::{guest::env, serde::to_vec};
 
 fn main() {
     let PrivacyPreservingCircuitInput {

--- a/nssa/program_methods/guest/src/bin/token.rs
+++ b/nssa/program_methods/guest/src/bin/token.rs
@@ -6,25 +6,22 @@ use nssa_core::{
 };
 
 // The token program has three functions:
-// 1. New token definition.
-//    Arguments to this function are:
-//      * Two **default** accounts: [definition_account, holding_account].
-//        The first default account will be initialized with the token definition account values. The second account will
-//        be initialized to a token holding account for the new token, holding the entire total supply.
-//      * An instruction data of 23-bytes, indicating the total supply and the token name, with
-//        the following layout:
-//        [0x00 || total_supply (little-endian 16 bytes) || name (6 bytes)]
-//        The name cannot be equal to [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
-// 2. Token transfer
-//    Arguments to this function are:
+// 1. New token definition. Arguments to this function are:
+//      * Two **default** accounts: [definition_account, holding_account]. The first default account
+//        will be initialized with the token definition account values. The second account will be
+//        initialized to a token holding account for the new token, holding the entire total supply.
+//      * An instruction data of 23-bytes, indicating the total supply and the token name, with the
+//        following layout: [0x00 || total_supply (little-endian 16 bytes) || name (6 bytes)] The
+//        name cannot be equal to [0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
+// 2. Token transfer Arguments to this function are:
 //      * Two accounts: [sender_account, recipient_account].
-//      * An instruction data byte string of length 23, indicating the total supply with the following layout
-//        [0x01 || amount (little-endian 16 bytes) || 0x00 || 0x00 || 0x00 || 0x00 || 0x00 || 0x00].
-// 3. Initialize account with zero balance
-//    Arguments to this function are:
+//      * An instruction data byte string of length 23, indicating the total supply with the
+//        following layout [0x01 || amount (little-endian 16 bytes) || 0x00 || 0x00 || 0x00 || 0x00
+//        || 0x00 || 0x00].
+// 3. Initialize account with zero balance Arguments to this function are:
 //      * Two accounts: [definition_account, account_to_initialize].
-//      * An dummy byte string of length 23, with the following layout
-//        [0x02 || 0x00 || 0x00 || 0x00 || ... || 0x00 || 0x00].
+//      * An dummy byte string of length 23, with the following layout [0x02 || 0x00 || 0x00 || 0x00
+//        || ... || 0x00 || 0x00].
 
 const TOKEN_DEFINITION_TYPE: u8 = 0;
 const TOKEN_DEFINITION_DATA_SIZE: usize = 23;

--- a/wallet/src/chain_storage.rs
+++ b/wallet/src/chain_storage.rs
@@ -263,6 +263,7 @@ mod tests {
             seq_poll_max_retries: 10,
             seq_block_poll_max_amount: 100,
             initial_accounts: create_initial_accounts(),
+            basic_auth: None,
         }
     }
 

--- a/wallet/src/cli/config.rs
+++ b/wallet/src/cli/config.rs
@@ -73,6 +73,13 @@ impl WalletSubcommand for ConfigSubcommand {
                 "initial_accounts" => {
                     println!("{:#?}", wallet_core.storage.wallet_config.initial_accounts);
                 }
+                "basic_auth" => {
+                    if let Some(basic_auth) = &wallet_core.storage.wallet_config.basic_auth {
+                        println!("{basic_auth}");
+                    } else {
+                        println!("Not set");
+                    }
+                }
                 _ => {
                     println!("Unknown field");
                 }
@@ -98,6 +105,9 @@ impl WalletSubcommand for ConfigSubcommand {
                     "seq_block_poll_max_amount" => {
                         wallet_core.storage.wallet_config.seq_block_poll_max_amount =
                             value.parse()?;
+                    }
+                    "basic_auth" => {
+                        wallet_core.storage.wallet_config.basic_auth = Some(value.parse()?);
                     }
                     "initial_accounts" => {
                         anyhow::bail!("Setting this field from wallet is not supported");
@@ -140,6 +150,9 @@ impl WalletSubcommand for ConfigSubcommand {
                 }
                 "initial_accounts" => {
                     println!("List of initial accounts' keys(both public and private)");
+                }
+                "basic_auth" => {
+                    println!("Basic authentication credentials for sequencer HTTP requests");
                 }
                 _ => {
                     println!("Unknown field");

--- a/wallet/src/cli/mod.rs
+++ b/wallet/src/cli/mod.rs
@@ -13,7 +13,7 @@ use crate::{
             token::TokenProgramAgnosticSubcommand,
         },
     },
-    helperfunctions::fetch_config,
+    helperfunctions::{fetch_config, merge_auth_config},
 };
 
 pub mod account;
@@ -69,7 +69,7 @@ pub enum OverCommand {
 
 /// To execute commands, env var NSSA_WALLET_HOME_DIR must be set into directory with config
 ///
-/// All account adresses must be valid 32 byte base58 strings.
+/// All account addresses must be valid 32 byte base58 strings.
 ///
 /// All account account_ids must be provided as {privacy_prefix}/{account_id},
 /// where valid options for `privacy_prefix` is `Public` and `Private`
@@ -79,6 +79,9 @@ pub struct Args {
     /// Continious run flag
     #[arg(short, long)]
     pub continuous_run: bool,
+    /// Basic authentication in the format `user` or `user:password`
+    #[arg(long)]
+    pub auth: Option<String>,
     /// Wallet command
     #[command(subcommand)]
     pub command: Option<OverCommand>,
@@ -94,7 +97,15 @@ pub enum SubcommandReturnValue {
 }
 
 pub async fn execute_subcommand(command: Command) -> Result<SubcommandReturnValue> {
+    execute_subcommand_with_auth(command, None).await
+}
+
+pub async fn execute_subcommand_with_auth(
+    command: Command,
+    auth: Option<String>,
+) -> Result<SubcommandReturnValue> {
     let wallet_config = fetch_config().await?;
+    let wallet_config = merge_auth_config(wallet_config, auth)?;
     let mut wallet_core = WalletCore::start_from_config_update_chain(wallet_config).await?;
 
     let subcommand_ret = match command {
@@ -160,7 +171,11 @@ pub async fn execute_subcommand(command: Command) -> Result<SubcommandReturnValu
 }
 
 pub async fn execute_continuous_run() -> Result<()> {
+    execute_continuous_run_with_auth(None).await
+}
+pub async fn execute_continuous_run_with_auth(auth: Option<String>) -> Result<()> {
     let config = fetch_config().await?;
+    let config = merge_auth_config(config, auth)?;
     let mut wallet_core = WalletCore::start_from_config_update_chain(config.clone()).await?;
 
     loop {
@@ -179,7 +194,12 @@ pub async fn execute_continuous_run() -> Result<()> {
 }
 
 pub async fn execute_setup(password: String) -> Result<()> {
+    execute_setup_with_auth(password, None).await
+}
+
+pub async fn execute_setup_with_auth(password: String, auth: Option<String>) -> Result<()> {
     let config = fetch_config().await?;
+    let config = merge_auth_config(config, auth)?;
     let wallet_core = WalletCore::start_from_config_new_storage(config.clone(), password).await?;
 
     wallet_core.store_persistent_data().await?;

--- a/wallet/src/helperfunctions.rs
+++ b/wallet/src/helperfunctions.rs
@@ -12,7 +12,7 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use crate::{
     HOME_DIR_ENV_VAR,
     config::{
-        InitialAccountData, InitialAccountDataPrivate, InitialAccountDataPublic,
+        BasicAuth, InitialAccountData, InitialAccountDataPrivate, InitialAccountDataPublic,
         PersistentAccountDataPrivate, PersistentAccountDataPublic, PersistentStorage, WalletConfig,
     },
 };
@@ -86,6 +86,23 @@ pub async fn fetch_config() -> Result<WalletConfig> {
         println!("Configs setted up");
     }
 
+    Ok(config)
+}
+
+/// Parse CLI auth string and merge with config auth, prioritizing CLI
+pub fn merge_auth_config(
+    mut config: WalletConfig,
+    cli_auth: Option<String>,
+) -> Result<WalletConfig> {
+    if let Some(auth_str) = cli_auth {
+        let cli_auth_config: BasicAuth = auth_str.parse()?;
+
+        if config.basic_auth.is_some() {
+            println!("Warning: CLI auth argument takes precedence over config basic-auth");
+        }
+
+        config.basic_auth = Some(cli_auth_config);
+    }
     Ok(config)
 }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -47,7 +47,14 @@ pub struct WalletCore {
 
 impl WalletCore {
     pub async fn start_from_config_update_chain(config: WalletConfig) -> Result<Self> {
-        let client = Arc::new(SequencerClient::new(config.sequencer_addr.clone())?);
+        let basic_auth = config
+            .basic_auth
+            .as_ref()
+            .map(|auth| (auth.username.clone(), auth.password.clone()));
+        let client = Arc::new(SequencerClient::new_with_auth(
+            config.sequencer_addr.clone(),
+            basic_auth,
+        )?);
         let tx_poller = TxPoller::new(config.clone(), client.clone());
 
         let PersistentStorage {
@@ -69,7 +76,14 @@ impl WalletCore {
         config: WalletConfig,
         password: String,
     ) -> Result<Self> {
-        let client = Arc::new(SequencerClient::new(config.sequencer_addr.clone())?);
+        let basic_auth = config
+            .basic_auth
+            .as_ref()
+            .map(|auth| (auth.username.clone(), auth.password.clone()));
+        let client = Arc::new(SequencerClient::new_with_auth(
+            config.sequencer_addr.clone(),
+            basic_auth,
+        )?);
         let tx_poller = TxPoller::new(config.clone(), client.clone());
 
         let storage = WalletChainStore::new_storage(config, password)?;


### PR DESCRIPTION
## 🎯 Purpose

Add basic auth to wallet to allow interaction with protected environments like testnet.

## ⚙️ Approach

Added `--auth` cli flag as well as config parameters. Cli flag takes precedence.

## 🧪 How to Test

1. Set testnet url in wallet config
2. Run:
  ```bash
  cargo run --bin wallet -- --auth user:password command check-health
  ```

Replacing `user` and `password` with actual credentials

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
