### PR TITLE
Remove print spam when running wallet account sync-private

### DIFF
--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -23,6 +23,7 @@ itertools.workspace = true
 sha2.workspace = true
 futures.workspace = true
 async-stream = "0.3.6"
+indicatif = { version = "0.18.3", features = ["improved_unicode"] }
 
 [dependencies.key_protocol]
 path = "../key_protocol"

--- a/wallet/src/chain_storage.rs
+++ b/wallet/src/chain_storage.rs
@@ -8,6 +8,7 @@ use key_protocol::{
     },
     key_protocol_core::NSSAUserData,
 };
+use log::debug;
 use nssa::program::Program;
 
 use crate::config::{InitialAccountData, PersistentAccountData, WalletConfig};
@@ -127,7 +128,7 @@ impl WalletChainStore {
         account_id: nssa::AccountId,
         account: nssa_core::account::Account,
     ) {
-        println!("inserting at address {account_id}, this account {account:?}");
+        debug!("inserting at address {account_id}, this account {account:?}");
 
         let entry = self
             .user_data


### PR DESCRIPTION
## 🎯 Purpose

Solves:
- https://github.com/logos-blockchain/lssa/issues/186

## ⚙️ Approach

- All intermediate prints moved to `info` or `debug` logging level
- Added progress bar from [indicatif](https://crates.io/crates/indicatif) crate to improve UX when sync takes a lot of time

Current example output:

<img width="853" height="60" alt="image" src="https://github.com/user-attachments/assets/f4122af4-07ed-464d-a749-d1b9c5eb3705" />


## 🧪 How to Test

1. Run sequencer
2. Submit some amount of private tx:
    ```bash
    for i in {1..10}; do
      echo "Sending transaction #$i"
      NSSA_WALLET_HOME_DIR=$(pwd)/integration_tests/configs/debug/wallet/ ./target/debug/wallet command auth-transfer send --amount 1 --from Private/3oCG8gqdKLMegw4rRfyaMQvuPHpcASt7xwttsmnZLSkw --to Private/ATe2o4nt9jPEGW8q8v6a28WkeZ5FquRvqVzNC5siW5h6
    done
    ```
3. Run sync:
    ```bash
    NSSA_WALLET_HOME_DIR=$(pwd)/integration_tests/configs/debug/wallet/ cargo run --bin wallet command account sync-private
    ```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
