### PR TITLE
Rearrange nonce increment for privacy transactions

### DIFF
--- a/nssa/program_methods/guest/src/bin/privacy_preserving_circuit.rs
+++ b/nssa/program_methods/guest/src/bin/privacy_preserving_circuit.rs
@@ -141,9 +141,7 @@ fn main() {
                 public_pre_states.push(pre_states[i].clone());
 
                 let mut post = state_diff.get(&pre_states[i].account_id).unwrap().clone();
-                if pre_states[i].is_authorized {
-                    post.nonce += 1;
-                }
+
                 if post.program_owner == DEFAULT_PROGRAM_ID {
                     // Claim account
                     post.program_owner = program_id;

--- a/nssa/src/privacy_preserving_transaction/circuit.rs
+++ b/nssa/src/privacy_preserving_transaction/circuit.rs
@@ -195,7 +195,7 @@ mod tests {
         let expected_sender_post = Account {
             program_owner: program.id(),
             balance: 100 - balance_to_move,
-            nonce: 1,
+            nonce: 0,
             data: Data::default(),
         };
 

--- a/nssa/src/state.rs
+++ b/nssa/src/state.rs
@@ -154,6 +154,12 @@ impl V02State {
             *current_account = post;
         }
 
+        // 5. Increment nonces for public signers
+        for account_id in tx.signer_account_ids() {
+            let current_account = self.get_account_by_id_mut(account_id);
+            current_account.nonce += 1;
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
## 🎯 Purpose

Shift nonce increment code for public signers in privacy transactions from the circuit to state transition.

## ⚙️ Approach

- [x] Remove nonces increment from privacy preserving circuit.
- [x] Add nonce increment to privacy transition in `state.rs`.

## 🧪 How to Test

Pre-existing tests:
`prove_privacy_preserving_execution_circuit_public_and_private_pre_accounts`
`test_transition_from_privacy_preserving_transaction_shielded` 

All pre-existing tests should still work

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
