### PR TITLE
fix: add `bindgen-runtime` feature of rocksdb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ itertools = "0.14.0"
 
 rocksdb = { version = "0.24.0", default-features = false, features = [
   "snappy",
+  "bindgen-runtime",
 ] }
 
 [workspace.dependencies.rand]


### PR DESCRIPTION
## 🎯 Purpose

Fixes build problems on MacOs after upgarding to rocksdb 24.0

## ⚙️ Approach

Activated rocksdb feature to use dynamic linking with libclang 

## 🧪 How to Test

`cargo build` on MacOs

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
