### PR TITLE
Remove trailing commas on `wallet account ls` output

### DIFF
--- a/wallet/src/cli/account.rs
+++ b/wallet/src/cli/account.rs
@@ -278,7 +278,7 @@ impl WalletSubcommand for AccountSubcommand {
                             .iter()
                             .map(|(id, chain_index)| format!("{chain_index} Private/{id}")),
                     )
-                    .format(",\n");
+                    .format("\n");
 
                 println!("{accounts}");
                 Ok(SubcommandReturnValue::Empty)


### PR DESCRIPTION
## 🎯 Purpose

The trailing commas is inconvenient:

1. For users trying to select an account id by double-clicking it in a terminal: the comma gets included in the selection
2. For dev parsing the `wallet account list` output: the commas needs to be handled

This PR removes it.

## ⚙️ Approach

- [x] Remove trailing comma after account id in the output of `wallet account list`

## 🧪 How to Test

1. run `wallet account list`
2. enjoy the lack of trailing comma by double clicking on an id and getting exactly just the id
3. type `wallet account get --account-id ` and paste your id: no comma to delete

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- ~~[ ] Add/update tests~~ CLI output is not tested
- ~~[ ] Add/update documentation and inline comments~~ Unnecessary
