### PR TITLE
add `wallet account label` feature

### DIFF
--- a/wallet/src/chain_storage.rs
+++ b/wallet/src/chain_storage.rs
@@ -16,12 +16,14 @@ use crate::config::{InitialAccountData, PersistentAccountData, WalletConfig};
 pub struct WalletChainStore {
     pub user_data: NSSAUserData,
     pub wallet_config: WalletConfig,
+    pub labels: HashMap<String, String>,
 }
 
 impl WalletChainStore {
     pub fn new(
         config: WalletConfig,
         persistent_accounts: Vec<PersistentAccountData>,
+        labels: HashMap<String, String>,
     ) -> Result<Self> {
         if persistent_accounts.is_empty() {
             anyhow::bail!("Roots not found; please run setup beforehand");
@@ -85,6 +87,7 @@ impl WalletChainStore {
                 private_tree,
             )?,
             wallet_config: config,
+            labels,
         })
     }
 
@@ -120,6 +123,7 @@ impl WalletChainStore {
                 private_tree,
             )?,
             wallet_config: config,
+            labels: HashMap::new(),
         })
     }
 
@@ -291,6 +295,6 @@ mod tests {
         let config = create_sample_wallet_config();
         let accs = create_sample_persistent_accounts();
 
-        let _ = WalletChainStore::new(config.clone(), accs).unwrap();
+        let _ = WalletChainStore::new(config.clone(), accs, HashMap::new()).unwrap();
     }
 }

--- a/wallet/src/config.rs
+++ b/wallet/src/config.rs
@@ -1,4 +1,4 @@
-use std::str::FromStr;
+use std::{collections::HashMap, str::FromStr};
 
 use key_protocol::key_management::{
     KeyChain,
@@ -103,6 +103,9 @@ pub enum PersistentAccountData {
 pub struct PersistentStorage {
     pub accounts: Vec<PersistentAccountData>,
     pub last_synced_block: u64,
+    /// Account labels keyed by account ID string (e.g., "2rnKprXqWGWJTkDZKsQbFXa4ctKRbapsdoTKQFnaVGG8")
+    #[serde(default)]
+    pub labels: HashMap<String, String>,
 }
 
 impl InitialAccountData {

--- a/wallet/src/helperfunctions.rs
+++ b/wallet/src/helperfunctions.rs
@@ -1,4 +1,4 @@
-use std::{path::PathBuf, str::FromStr};
+use std::{collections::HashMap, path::PathBuf, str::FromStr};
 
 use anyhow::Result;
 use base64::{Engine, engine::general_purpose::STANDARD as BASE64};
@@ -134,6 +134,7 @@ pub async fn fetch_persistent_storage() -> Result<PersistentStorage> {
 pub fn produce_data_for_storage(
     user_data: &NSSAUserData,
     last_synced_block: u64,
+    labels: HashMap<String, String>,
 ) -> PersistentStorage {
     let mut vec_for_storage = vec![];
 
@@ -187,6 +188,7 @@ pub fn produce_data_for_storage(
     PersistentStorage {
         accounts: vec_for_storage,
         last_synced_block,
+        labels,
     }
 }
 

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -145,9 +145,10 @@ impl WalletCore {
         let PersistentStorage {
             accounts: persistent_accounts,
             last_synced_block,
+            labels,
         } = fetch_persistent_storage().await?;
 
-        let storage = WalletChainStore::new(config, persistent_accounts)?;
+        let storage = WalletChainStore::new(config, persistent_accounts, labels)?;
 
         Ok(Self {
             storage,
@@ -186,7 +187,11 @@ impl WalletCore {
         let home = get_home()?;
         let storage_path = home.join("storage.json");
 
-        let data = produce_data_for_storage(&self.storage.user_data, self.last_synced_block);
+        let data = produce_data_for_storage(
+            &self.storage.user_data,
+            self.last_synced_block,
+            self.storage.labels.clone(),
+        );
         let storage = serde_json::to_vec_pretty(&data)?;
 
         let mut storage_file = tokio::fs::File::create(storage_path.as_path()).await?;


### PR DESCRIPTION
## 🎯 Purpose

LSSA's account based approach is such as a user has to manipulate a good number of accounts.

To make the task easier, we add a label feature to the `wallet` CLI.

## ⚙️ Approach

- can add a label to own account via `wallet` CLI
- labels are displayed with `wallet account get` command
- labels are displayed with `wallet account list` command
- labels are persisted.

## 🧪 How to Test

Try the following commands:

- `wallet account label --label "some string" --account-id <...>`
- `wallet account get --account-id <...>`
- `wallet account list`

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- ~~[ ] Add/update tests~~ No test on CLI output
- [x] Add/update documentation and inline comments

Note: I used AI to get familiar with the code structure. It works but let me know if code architecture isn't ideal.