### PR TITLE
fix: program deployment tutorial

### DIFF
--- a/examples/program_deployment/README.md
+++ b/examples/program_deployment/README.md
@@ -41,13 +41,15 @@ In a second terminal, from the `lssa` root directory, compile the example Risc0 
 ```bash
 cargo risczero build --manifest-path examples/program_deployment/methods/guest/Cargo.toml
 ```
-The compiled `.bin` files will appear under:
+Because this repository is organized as a Cargo workspace, build artifacts are written to the
+shared `target/` directory at the workspace root by default. The compiled `.bin` files will
+appear under:
 ```
-examples/program_deployment/methods/guest/target/riscv32im-risc0-zkvm-elf/docker/
+target/riscv32im-risc0-zkvm-elf/docker/
 ```
 For convenience, export this path:
 ```bash
-export EXAMPLE_PROGRAMS_BUILD_DIR=$(pwd)/examples/program_deployment/methods/guest/target/riscv32im-risc0-zkvm-elf/docker
+export EXAMPLE_PROGRAMS_BUILD_DIR=$(pwd)/target/riscv32im-risc0-zkvm-elf/docker
 ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## 🎯 Purpose

Update the program deployment tutorial to reflect the actual output location of compiled Risc0 guest binaries in the Cargo workspace.

- Fixes a docs inconsistency where the tutorial pointed to a crate-local `target/` directory that is never populated by the current workspace configuration.
- Aligns the documented `EXAMPLE_PROGRAMS_BUILD_DIR` with the real paths produced by `cargo risczero build`.

## ⚙️ Approach

Adjust the `examples/program_deployment/README.md` tutorial so it describes the shared workspace `target/` directory and exports an environment variable that matches the real build artifacts.

- [x] Change the documented output directory from `examples/program_deployment/methods/guest/target/riscv32im-risc0-zkvm-elf/docker/` to `target/riscv32im-risc0-zkvm-elf/docker/`.
- [x] Update `EXAMPLE_PROGRAMS_BUILD_DIR` to `$(pwd)/target/riscv32im-risc0-zkvm-elf/docker`.
- [x] Ensure all subsequent commands in the tutorial that reference `$EXAMPLE_PROGRAMS_BUILD_DIR/*.bin` remain correct with the new path.
- [ ] Add any additional clarifications about workspace behavior if reviewers feel it’s useful for new contributors.

## 🧪 How to Test

1. From the repo root, compile the example programs:
   ```bash
   cargo risczero build --manifest-path examples/program_deployment/methods/guest/Cargo.toml
   ```
2. Confirm that the compiled binaries exist under:
   ```bash
   ls target/riscv32im-risc0-zkvm-elf/docker
   # expected: hello_world.bin, hello_world_with_authorization.bin, hello_world_with_move_function.bin, simple_tail_call.bin, tail_call_with_pda.bin
   ```
3. Export the path as described in the updated docs:
   ```bash
   export EXAMPLE_PROGRAMS_BUILD_DIR=$(pwd)/target/riscv32im-risc0-zkvm-elf/docker
   ```
4. Run one of the tutorial commands that uses this variable, for example:
   ```bash
   wallet deploy-program "$EXAMPLE_PROGRAMS_BUILD_DIR/hello_world.bin"
   ```
   and verify that it succeeds without needing to adjust the path.

## 🔗 Dependencies

None. This PR only updates documentation and does not depend on other changes.

## 🔜 Future Work

- Optionally, add a brief note in the tutorial explaining that LSSA is organized as a Cargo workspace and that build artifacts use a shared `target/` directory by default.
- Consider adding a short troubleshooting section for “build succeeded but `.bin` file not found at documented path” pointing to the workspace `target/` location.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests (not applicable: docs-only change)
- [x] Add/update documentation and inline comments

