### PR TITLE
add wallet account keys command to display ipk/npk

### DIFF
--- a/wallet/src/cli/account.rs
+++ b/wallet/src/cli/account.rs
@@ -231,24 +231,8 @@ impl WalletSubcommand for AccountSubcommand {
                         .ok_or(anyhow::anyhow!("Private account not found in storage"))?,
                 };
 
-                if account == Account::default() {
-                    println!("Account is Uninitialized");
-
-                    return Ok(SubcommandReturnValue::Empty);
-                }
-
-                if raw {
-                    let account_hr: HumanReadableAccount = account.clone().into();
-                    println!("{}", serde_json::to_string(&account_hr).unwrap());
-
-                    return Ok(SubcommandReturnValue::Empty);
-                }
-
-                let (description, json_view) = format_account_details(&account);
-                println!("{description}");
-                println!("{json_view}");
-
-                if keys {
+                // Helper closure to display keys for the account
+                let display_keys = |wallet_core: &WalletCore| -> Result<()> {
                     match addr_kind {
                         AccountPrivacyKind::Public => {
                             let private_key = wallet_core
@@ -274,6 +258,32 @@ impl WalletSubcommand for AccountSubcommand {
                             );
                         }
                     }
+                    Ok(())
+                };
+
+                if account == Account::default() {
+                    println!("Account is Uninitialized");
+
+                    if keys {
+                        display_keys(wallet_core)?;
+                    }
+
+                    return Ok(SubcommandReturnValue::Empty);
+                }
+
+                if raw {
+                    let account_hr: HumanReadableAccount = account.clone().into();
+                    println!("{}", serde_json::to_string(&account_hr).unwrap());
+
+                    return Ok(SubcommandReturnValue::Empty);
+                }
+
+                let (description, json_view) = format_account_details(&account);
+                println!("{description}");
+                println!("{json_view}");
+
+                if keys {
+                    display_keys(wallet_core)?;
                 }
 
                 Ok(SubcommandReturnValue::Empty)


### PR DESCRIPTION
## 🎯 Purpose

ipk and npk are needed to receive funds from an external account on a private account.

They are currently only displayed at account creation (`wallet account new private`). With this command, it is now possible to print them at any time.

## ⚙️ Approach

- [x] add `wallet account get --keys` option, see example below

```
▶ wallet account get --account-id Private/FX6ToXKFoPhPfVVJXKFRk3tgSmAk1XAQHdpV4ksAi1vz --keys
Account owned by authenticated transfer program
{"balance":150}
npk 0be0af2dfb1d28a7406b53ae6cc549c7d78b08afd33531673cd263d5b6989b45
ipk 022e1e35dea6cb609c7a988205ee73af8df1ed1a8738e7ebdf9e6b2f1859bc6385

▶ wallet account get --account-id Public/7Jh5R6ohMuzbbBNrzgMAugUN7bHGCoVZXon8BzuLf4j8 --keys
Account owned by authenticated transfer program
{"balance":0}
Error: --keys option only works for private accounts
```

## 🧪 How to Test

run `wallet account get --keys --account-id <private account id>` for an account owned by your wallet.

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- ~~[ ] Add/update tests~~ no test on CLI output
- [x] Add/update documentation and inline comments (only inline comments)
- [x] Private accounts
- [x] Public accounts
- [x] Uninitialized accounts
