### PR TITLE
fix(wallet): use cryptographically secure entropy for mnemonic generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8684,6 +8684,7 @@ dependencies = [
  "async-stream",
  "ata_core",
  "base58",
+ "bip39",
  "clap",
  "common",
  "env_logger",

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -256,11 +256,11 @@ impl TestContext {
         let config_overrides = WalletConfigOverrides::default();
 
         let wallet_password = "test_pass".to_owned();
-        let wallet = WalletCore::new_init_storage(
+        let (wallet, _mnemonic) = WalletCore::new_init_storage(
             config_path,
             storage_path,
             Some(config_overrides),
-            wallet_password.clone(),
+            &wallet_password,
         )
         .context("Failed to init wallet")?;
         wallet

--- a/integration_tests/tests/wallet_ffi.rs
+++ b/integration_tests/tests/wallet_ffi.rs
@@ -24,7 +24,6 @@ use log::info;
 use nssa::{Account, AccountId, PrivateKey, PublicKey, program::Program};
 use nssa_core::program::DEFAULT_PROGRAM_ID;
 use tempfile::tempdir;
-use wallet::WalletCore;
 use wallet_ffi::{
     FfiAccount, FfiAccountList, FfiBytes32, FfiPrivateAccountKeys, FfiPublicAccountKey,
     FfiTransferResult, WalletHandle, error,
@@ -211,14 +210,6 @@ fn new_wallet_ffi_with_default_config(password: &str) -> Result<*mut WalletHandl
     })
 }
 
-fn new_wallet_rust_with_default_config(password: &str) -> Result<WalletCore> {
-    let tempdir = tempdir()?;
-    let config_path = tempdir.path().join("wallet_config.json");
-    let storage_path = tempdir.path().join("storage.json");
-
-    WalletCore::new_init_storage(config_path, storage_path, None, password.to_owned())
-}
-
 fn load_existing_ffi_wallet(home: &Path) -> Result<*mut WalletHandle> {
     let config_path = home.join("wallet_config.json");
     let storage_path = home.join("storage.json");
@@ -232,19 +223,8 @@ fn load_existing_ffi_wallet(home: &Path) -> Result<*mut WalletHandle> {
 fn wallet_ffi_create_public_accounts() -> Result<()> {
     let password = "password_for_tests";
     let n_accounts = 10;
-    // First `n_accounts` public accounts created with Rust wallet
-    let new_public_account_ids_rust = {
-        let mut account_ids = Vec::new();
 
-        let mut wallet_rust = new_wallet_rust_with_default_config(password)?;
-        for _ in 0..n_accounts {
-            let account_id = wallet_rust.create_new_account_public(None).0;
-            account_ids.push(*account_id.value());
-        }
-        account_ids
-    };
-
-    // First `n_accounts` public accounts created with wallet FFI
+    // Create `n_accounts` public accounts with wallet FFI
     let new_public_account_ids_ffi = unsafe {
         let mut account_ids = Vec::new();
 
@@ -258,7 +238,20 @@ fn wallet_ffi_create_public_accounts() -> Result<()> {
         account_ids
     };
 
-    assert_eq!(new_public_account_ids_ffi, new_public_account_ids_rust);
+    // All returned IDs must be unique and non-zero
+    assert_eq!(new_public_account_ids_ffi.len(), n_accounts);
+    let unique: HashSet<_> = new_public_account_ids_ffi.iter().collect();
+    assert_eq!(
+        unique.len(),
+        n_accounts,
+        "Duplicate public account IDs returned"
+    );
+    assert!(
+        new_public_account_ids_ffi
+            .iter()
+            .all(|id| *id != [0_u8; 32]),
+        "Zero account ID returned"
+    );
 
     Ok(())
 }
@@ -267,19 +260,7 @@ fn wallet_ffi_create_public_accounts() -> Result<()> {
 fn wallet_ffi_create_private_accounts() -> Result<()> {
     let password = "password_for_tests";
     let n_accounts = 10;
-    // First `n_accounts` private accounts created with Rust wallet
-    let new_private_account_ids_rust = {
-        let mut account_ids = Vec::new();
-
-        let mut wallet_rust = new_wallet_rust_with_default_config(password)?;
-        for _ in 0..n_accounts {
-            let account_id = wallet_rust.create_new_account_private(None).0;
-            account_ids.push(*account_id.value());
-        }
-        account_ids
-    };
-
-    // First `n_accounts` private accounts created with wallet FFI
+    // Create `n_accounts` private accounts with wallet FFI
     let new_private_account_ids_ffi = unsafe {
         let mut account_ids = Vec::new();
 
@@ -293,7 +274,20 @@ fn wallet_ffi_create_private_accounts() -> Result<()> {
         account_ids
     };
 
-    assert_eq!(new_private_account_ids_ffi, new_private_account_ids_rust);
+    // All returned IDs must be unique and non-zero
+    assert_eq!(new_private_account_ids_ffi.len(), n_accounts);
+    let unique: HashSet<_> = new_private_account_ids_ffi.iter().collect();
+    assert_eq!(
+        unique.len(),
+        n_accounts,
+        "Duplicate private account IDs returned"
+    );
+    assert!(
+        new_private_account_ids_ffi
+            .iter()
+            .all(|id| *id != [0_u8; 32]),
+        "Zero account ID returned"
+    );
 
     Ok(())
 }
@@ -349,28 +343,23 @@ fn wallet_ffi_save_and_load_persistent_storage() -> Result<()> {
 fn test_wallet_ffi_list_accounts() -> Result<()> {
     let password = "password_for_tests";
 
-    // Create the wallet FFI
-    let wallet_ffi_handle = unsafe {
+    // Create the wallet FFI and track which account IDs were created as public/private
+    let (wallet_ffi_handle, created_public_ids, created_private_ids) = unsafe {
         let handle = new_wallet_ffi_with_default_config(password)?;
-        // Create 5 public accounts and 5 private accounts
+        let mut public_ids: Vec<[u8; 32]> = Vec::new();
+        let mut private_ids: Vec<[u8; 32]> = Vec::new();
+
+        // Create 5 public accounts and 5 private accounts, recording their IDs
         for _ in 0..5 {
             let mut out_account_id = FfiBytes32::from_bytes([0; 32]);
             wallet_ffi_create_account_public(handle, &raw mut out_account_id);
+            public_ids.push(out_account_id.data);
+
             wallet_ffi_create_account_private(handle, &raw mut out_account_id);
+            private_ids.push(out_account_id.data);
         }
 
-        handle
-    };
-
-    // Create the wallet Rust
-    let wallet_rust = {
-        let mut wallet = new_wallet_rust_with_default_config(password)?;
-        // Create 5 public accounts and 5 private accounts
-        for _ in 0..5 {
-            wallet.create_new_account_public(None);
-            wallet.create_new_account_private(None);
-        }
-        wallet
+        (handle, public_ids, private_ids)
     };
 
     // Get the account list with FFI method
@@ -380,15 +369,6 @@ fn test_wallet_ffi_list_accounts() -> Result<()> {
         out_list
     };
 
-    let wallet_rust_account_ids = wallet_rust
-        .storage()
-        .user_data
-        .account_ids()
-        .collect::<Vec<_>>();
-
-    // Assert same number of elements between Rust and FFI result
-    assert_eq!(wallet_rust_account_ids.len(), wallet_ffi_account_list.count);
-
     let wallet_ffi_account_list_slice = unsafe {
         core::slice::from_raw_parts(
             wallet_ffi_account_list.entries,
@@ -396,37 +376,38 @@ fn test_wallet_ffi_list_accounts() -> Result<()> {
         )
     };
 
-    // Assert same account ids between Rust and FFI result
-    assert_eq!(
-        wallet_rust_account_ids
-            .iter()
-            .map(nssa::AccountId::value)
-            .collect::<HashSet<_>>(),
-        wallet_ffi_account_list_slice
-            .iter()
-            .map(|entry| &entry.account_id.data)
-            .collect::<HashSet<_>>()
-    );
+    // All created accounts must appear in the list
+    let listed_public_ids: HashSet<[u8; 32]> = wallet_ffi_account_list_slice
+        .iter()
+        .filter(|e| e.is_public)
+        .map(|e| e.account_id.data)
+        .collect();
+    let listed_private_ids: HashSet<[u8; 32]> = wallet_ffi_account_list_slice
+        .iter()
+        .filter(|e| !e.is_public)
+        .map(|e| e.account_id.data)
+        .collect();
 
-    // Assert `is_pub` flag is correct in the FFI result
-    for entry in wallet_ffi_account_list_slice {
-        let account_id = AccountId::new(entry.account_id.data);
-        let is_pub_default_in_rust_wallet = wallet_rust
-            .storage()
-            .user_data
-            .default_pub_account_signing_keys
-            .contains_key(&account_id);
-        let is_pub_key_tree_wallet_rust = wallet_rust
-            .storage()
-            .user_data
-            .public_key_tree
-            .account_id_map
-            .contains_key(&account_id);
-
-        let is_public_in_rust_wallet = is_pub_default_in_rust_wallet || is_pub_key_tree_wallet_rust;
-
-        assert_eq!(entry.is_public, is_public_in_rust_wallet);
+    for id in &created_public_ids {
+        assert!(
+            listed_public_ids.contains(id),
+            "Created public account not found in list with is_public=true"
+        );
     }
+    for id in &created_private_ids {
+        assert!(
+            listed_private_ids.contains(id),
+            "Created private account not found in list with is_public=false"
+        );
+    }
+
+    // Total listed accounts must be at least the number we created
+    assert!(
+        wallet_ffi_account_list.count >= created_public_ids.len() + created_private_ids.len(),
+        "Listed account count ({}) is less than the number of created accounts ({})",
+        wallet_ffi_account_list.count,
+        created_public_ids.len() + created_private_ids.len()
+    );
 
     unsafe {
         wallet_ffi_free_account_list(&raw mut wallet_ffi_account_list);

--- a/key_protocol/src/key_management/mod.rs
+++ b/key_protocol/src/key_management/mod.rs
@@ -42,10 +42,10 @@ impl KeyChain {
     }
 
     #[must_use]
-    pub fn new_mnemonic(passphrase: String) -> Self {
+    pub fn new_mnemonic(passphrase: &str) -> (Self, bip39::Mnemonic) {
         // Currently dropping SeedHolder at the end of initialization.
         // Not entirely sure if we need it in the future.
-        let seed_holder = SeedHolder::new_mnemonic(passphrase);
+        let (seed_holder, mnemonic) = SeedHolder::new_mnemonic(passphrase);
         let secret_spending_key = seed_holder.produce_top_secret_key_holder();
 
         let private_key_holder = secret_spending_key.produce_private_key_holder(None);
@@ -53,12 +53,15 @@ impl KeyChain {
         let nullifier_public_key = private_key_holder.generate_nullifier_public_key();
         let viewing_public_key = private_key_holder.generate_viewing_public_key();
 
-        Self {
-            secret_spending_key,
-            private_key_holder,
-            nullifier_public_key,
-            viewing_public_key,
-        }
+        (
+            Self {
+                secret_spending_key,
+                private_key_holder,
+                nullifier_public_key,
+                viewing_public_key,
+            },
+            mnemonic,
+        )
     }
 
     #[must_use]

--- a/key_protocol/src/key_management/secret_holders.rs
+++ b/key_protocol/src/key_management/secret_holders.rs
@@ -8,8 +8,6 @@ use rand::{RngCore as _, rngs::OsRng};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, digest::FixedOutput as _};
 
-const NSSA_ENTROPY_BYTES: [u8; 32] = [0; 32];
-
 /// Seed holder. Non-clonable to ensure that different holders use different seeds.
 /// Produces `TopSecretKeyHolder` objects.
 #[derive(Debug)]
@@ -48,9 +46,24 @@ impl SeedHolder {
     }
 
     #[must_use]
-    pub fn new_mnemonic(passphrase: String) -> Self {
-        let mnemonic = Mnemonic::from_entropy(&NSSA_ENTROPY_BYTES)
-            .expect("Enthropy must be a multiple of 32 bytes");
+    pub fn new_mnemonic(passphrase: &str) -> (Self, Mnemonic) {
+        let mut entropy_bytes: [u8; 32] = [0; 32];
+        OsRng.fill_bytes(&mut entropy_bytes);
+
+        let mnemonic =
+            Mnemonic::from_entropy(&entropy_bytes).expect("Entropy must be a multiple of 32 bytes");
+        let seed_wide = mnemonic.to_seed(passphrase);
+
+        (
+            Self {
+                seed: seed_wide.to_vec(),
+            },
+            mnemonic,
+        )
+    }
+
+    #[must_use]
+    pub fn from_mnemonic(mnemonic: &Mnemonic, passphrase: &str) -> Self {
         let seed_wide = mnemonic.to_seed(passphrase);
 
         Self {
@@ -175,12 +188,63 @@ mod tests {
     }
 
     #[test]
-    fn two_seeds_generated_same_from_same_mnemonic() {
-        let mnemonic = "test_pass";
+    fn two_seeds_recovered_same_from_same_mnemonic() {
+        let passphrase = "test_pass";
 
-        let seed_holder1 = SeedHolder::new_mnemonic(mnemonic.to_owned());
-        let seed_holder2 = SeedHolder::new_mnemonic(mnemonic.to_owned());
+        // Generate a mnemonic with random entropy
+        let (original_seed_holder, mnemonic) = SeedHolder::new_mnemonic(passphrase);
 
-        assert_eq!(seed_holder1.seed, seed_holder2.seed);
+        // Recover from the same mnemonic
+        let recovered_seed_holder = SeedHolder::from_mnemonic(&mnemonic, passphrase);
+
+        assert_eq!(original_seed_holder.seed, recovered_seed_holder.seed);
+    }
+
+    #[test]
+    fn new_mnemonic_generates_different_seeds_each_time() {
+        let (seed_holder1, mnemonic1) = SeedHolder::new_mnemonic("");
+        let (seed_holder2, mnemonic2) = SeedHolder::new_mnemonic("");
+
+        // Different entropy should produce different mnemonics and seeds
+        assert_ne!(mnemonic1.to_string(), mnemonic2.to_string());
+        assert_ne!(seed_holder1.seed, seed_holder2.seed);
+    }
+
+    #[test]
+    fn new_mnemonic_generates_24_word_phrase() {
+        let (_seed_holder, mnemonic) = SeedHolder::new_mnemonic("");
+
+        // 256 bits of entropy produces a 24-word mnemonic
+        let word_count = mnemonic.to_string().split_whitespace().count();
+        assert_eq!(word_count, 24);
+    }
+
+    #[test]
+    fn new_mnemonic_produces_valid_seed_length() {
+        let (seed_holder, _mnemonic) = SeedHolder::new_mnemonic("");
+
+        assert_eq!(seed_holder.seed.len(), 64);
+    }
+
+    #[test]
+    fn different_passphrases_produce_different_seeds() {
+        let (_seed_holder, mnemonic) = SeedHolder::new_mnemonic("");
+
+        let seed_with_pass_a = SeedHolder::from_mnemonic(&mnemonic, "password_a");
+        let seed_with_pass_b = SeedHolder::from_mnemonic(&mnemonic, "password_b");
+
+        // Same mnemonic but different passphrases should produce different seeds
+        assert_ne!(seed_with_pass_a.seed, seed_with_pass_b.seed);
+    }
+
+    #[test]
+    fn empty_passphrase_is_deterministic() {
+        let (_seed_holder, mnemonic) = SeedHolder::new_mnemonic("");
+
+        let seed1 = SeedHolder::from_mnemonic(&mnemonic, "");
+        let seed2 = SeedHolder::from_mnemonic(&mnemonic, "");
+
+        // Same mnemonic and passphrase should always produce the same seed
+        assert_eq!(seed1.seed, seed2.seed);
     }
 }

--- a/key_protocol/src/key_protocol_core/mod.rs
+++ b/key_protocol/src/key_protocol_core/mod.rs
@@ -181,11 +181,12 @@ impl NSSAUserData {
 
 impl Default for NSSAUserData {
     fn default() -> Self {
+        let (seed_holder, _mnemonic) = SeedHolder::new_mnemonic("");
         Self::new_with_accounts(
             BTreeMap::new(),
             BTreeMap::new(),
-            KeyTreePublic::new(&SeedHolder::new_mnemonic("default".to_owned())),
-            KeyTreePrivate::new(&SeedHolder::new_mnemonic("default".to_owned())),
+            KeyTreePublic::new(&seed_holder),
+            KeyTreePrivate::new(&seed_holder),
         )
         .unwrap()
     }

--- a/wallet-ffi/src/wallet.rs
+++ b/wallet-ffi/src/wallet.rs
@@ -111,8 +111,8 @@ pub unsafe extern "C" fn wallet_ffi_create_new(
         return ptr::null_mut();
     };
 
-    match WalletCore::new_init_storage(config_path, storage_path, None, password) {
-        Ok(core) => {
+    match WalletCore::new_init_storage(config_path, storage_path, None, &password) {
+        Ok((core, _mnemonic)) => {
             let wrapper = Box::new(WalletWrapper {
                 core: Mutex::new(core),
             });

--- a/wallet/Cargo.toml
+++ b/wallet/Cargo.toml
@@ -17,6 +17,7 @@ token_core.workspace = true
 amm_core.workspace = true
 testnet_initial_state.workspace = true
 ata_core.workspace = true
+bip39.workspace = true
 
 anyhow.workspace = true
 thiserror.workspace = true

--- a/wallet/src/chain_storage.rs
+++ b/wallet/src/chain_storage.rs
@@ -1,6 +1,7 @@
 use std::collections::{BTreeMap, HashMap, btree_map::Entry};
 
 use anyhow::Result;
+use bip39::Mnemonic;
 use key_protocol::{
     key_management::{
         key_tree::{KeyTreePrivate, KeyTreePublic, chain_index::ChainIndex},
@@ -95,7 +96,7 @@ impl WalletChainStore {
         })
     }
 
-    pub fn new_storage(config: WalletConfig, password: String) -> Result<Self> {
+    pub fn new_storage(config: WalletConfig, password: &str) -> Result<(Self, Mnemonic)> {
         let mut public_init_acc_map = BTreeMap::new();
         let mut private_init_acc_map = BTreeMap::new();
 
@@ -121,13 +122,43 @@ impl WalletChainStore {
             }
         }
 
-        let public_tree = KeyTreePublic::new(&SeedHolder::new_mnemonic(password.clone()));
-        let private_tree = KeyTreePrivate::new(&SeedHolder::new_mnemonic(password));
+        // TODO: Use password for storage encryption
+        let _ = password;
+        let (seed_holder, mnemonic) = SeedHolder::new_mnemonic("");
+        let public_tree = KeyTreePublic::new(&seed_holder);
+        let private_tree = KeyTreePrivate::new(&seed_holder);
+
+        Ok((
+            Self {
+                user_data: NSSAUserData::new_with_accounts(
+                    public_init_acc_map,
+                    private_init_acc_map,
+                    public_tree,
+                    private_tree,
+                )?,
+                wallet_config: config,
+                labels: HashMap::new(),
+            },
+            mnemonic,
+        ))
+    }
+
+    /// Restore storage from an existing mnemonic phrase.
+    pub fn restore_storage(
+        config: WalletConfig,
+        mnemonic: &Mnemonic,
+        password: &str,
+    ) -> Result<Self> {
+        // TODO: Use password for storage encryption
+        let _ = password;
+        let seed_holder = SeedHolder::from_mnemonic(mnemonic, "");
+        let public_tree = KeyTreePublic::new(&seed_holder);
+        let private_tree = KeyTreePrivate::new(&seed_holder);
 
         Ok(Self {
             user_data: NSSAUserData::new_with_accounts(
-                public_init_acc_map,
-                private_init_acc_map,
+                BTreeMap::new(),
+                BTreeMap::new(),
                 public_tree,
                 private_tree,
             )?,

--- a/wallet/src/cli/mod.rs
+++ b/wallet/src/cli/mod.rs
@@ -1,6 +1,7 @@
-use std::{io::Write as _, path::PathBuf};
+use std::{io::Write as _, path::PathBuf, str::FromStr as _};
 
 use anyhow::{Context as _, Result};
+use bip39::Mnemonic;
 use clap::{Parser, Subcommand};
 use common::{HashType, transaction::NSSATransaction};
 use futures::TryFutureExt as _;
@@ -167,8 +168,9 @@ pub async fn execute_subcommand(
             config_subcommand.handle_subcommand(wallet_core).await?
         }
         Command::RestoreKeys { depth } => {
+            let mnemonic = read_mnemonic_from_stdin()?;
             let password = read_password_from_stdin()?;
-            wallet_core.reset_storage(password)?;
+            wallet_core.restore_storage(&mnemonic, &password)?;
             execute_keys_restoration(wallet_core, depth).await?;
 
             SubcommandReturnValue::Empty
@@ -210,6 +212,16 @@ pub fn read_password_from_stdin() -> Result<String> {
     std::io::stdin().read_line(&mut password)?;
 
     Ok(password.trim().to_owned())
+}
+
+pub fn read_mnemonic_from_stdin() -> Result<Mnemonic> {
+    let mut phrase = String::new();
+
+    print!("Input recovery phrase: ");
+    std::io::stdout().flush()?;
+    std::io::stdin().read_line(&mut phrase)?;
+
+    Mnemonic::from_str(phrase.trim()).context("Invalid mnemonic phrase")
 }
 
 pub async fn execute_keys_restoration(wallet_core: &mut WalletCore, depth: u32) -> Result<()> {

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -11,6 +11,7 @@
 use std::path::PathBuf;
 
 use anyhow::{Context as _, Result};
+use bip39::Mnemonic;
 use chain_storage::WalletChainStore;
 use common::{HashType, transaction::NSSATransaction};
 use config::WalletConfig;
@@ -117,15 +118,24 @@ impl WalletCore {
         config_path: PathBuf,
         storage_path: PathBuf,
         config_overrides: Option<WalletConfigOverrides>,
-        password: String,
-    ) -> Result<Self> {
-        Self::new(
+        password: &str,
+    ) -> Result<(Self, Mnemonic)> {
+        let mut mnemonic_out = None;
+        let wallet = Self::new(
             config_path,
             storage_path,
             config_overrides,
-            |config| WalletChainStore::new_storage(config, password),
+            |config| {
+                let (storage, mnemonic) = WalletChainStore::new_storage(config, password)?;
+                mnemonic_out = Some(mnemonic);
+                Ok(storage)
+            },
             0,
-        )
+        )?;
+        Ok((
+            wallet,
+            mnemonic_out.expect("mnemonic should be set after new_storage"),
+        ))
     }
 
     fn new(
@@ -191,9 +201,13 @@ impl WalletCore {
         &self.storage
     }
 
-    /// Reset storage.
-    pub fn reset_storage(&mut self, password: String) -> Result<()> {
-        self.storage = WalletChainStore::new_storage(self.storage.wallet_config.clone(), password)?;
+    /// Restore storage from an existing mnemonic phrase.
+    pub fn restore_storage(&mut self, mnemonic: &Mnemonic, password: &str) -> Result<()> {
+        self.storage = WalletChainStore::restore_storage(
+            self.storage.wallet_config.clone(),
+            mnemonic,
+            password,
+        )?;
         Ok(())
     }
 

--- a/wallet/src/main.rs
+++ b/wallet/src/main.rs
@@ -46,12 +46,20 @@ async fn main() -> Result<()> {
             println!("Persistent storage not found, need to execute setup");
 
             let password = read_password_from_stdin()?;
-            let wallet = WalletCore::new_init_storage(
+            let (wallet, mnemonic) = WalletCore::new_init_storage(
                 config_path,
                 storage_path,
                 Some(config_overrides),
-                password,
+                &password,
             )?;
+
+            println!();
+            println!("IMPORTANT: Write down your recovery phrase and store it securely.");
+            println!("This is the only way to recover your wallet if you lose access.");
+            println!();
+            println!("Recovery phrase:");
+            println!("  {mnemonic}");
+            println!();
 
             wallet.store_persistent_data().await?;
             wallet


### PR DESCRIPTION

The mnemonic/wallet generation was using a constant zero-byte array for entropy ([0u8; 32]), making all wallets deterministic based solely on the password. This commit introduces proper random entropy using OsRng and enables users to back up their recovery phrase.

Changes:

- SeedHolder::new_mnemonic() now uses OsRng for 256-bit random entropy and returns the generated mnemonic
- Added SeedHolder::from_mnemonic() to recover a wallet from an existing mnemonic phrase
- WalletChainStore::new_storage() returns the mnemonic for user backup
- Added WalletChainStore::restore_storage() for recovery from a mnemonic
- WalletCore::new_init_storage() now returns the mnemonic
- Renamed reset_storage to restore_storage, which accepts a mnemonic for recovery
- CLI displays the recovery phrase when a new wallet is created
- RestoreKeys command now prompts for the mnemonic phrase via read_mnemonic_from_stdin()

Note: The password parameter is retained for future storage encryption but is no longer used in seed derivation (empty passphrase is used
 instead). This means the mnemonic alone is sufficient to recover accounts.

Usage:

On first wallet initialization, users will see:

```
IMPORTANT: Write down your recovery phrase and store it securely. This is the only way to recover your wallet if you lose access.

Recovery phrase:
  word1 word2 word3 ... word24

To restore keys:
wallet restore-keys --depth 5
Input recovery phrase: <24 words>
Input password: <password>
```
