### PR TITLE
bug(wallet): conflicting flag -h for transaction info

### DIFF
--- a/wallet/src/cli/chain.rs
+++ b/wallet/src/cli/chain.rs
@@ -19,7 +19,7 @@ pub enum ChainSubcommand {
     /// Get transaction at hash from sequencer
     Transaction {
         /// hash - valid 32 byte hex string
-        #[arg(short, long)]
+        #[arg(short = 't', long)]
         hash: String,
     },
 }


### PR DESCRIPTION
## 🎯 Purpose

Got this error while trying to get the TX info:

```
Command transaction: Short option names must be unique for each argument, but '-h' is in use by both 'hash' and 'help' (call `cmd.disable_help_flag(true)` to remove the auto-generated `--help`)
```

## ⚙️ Approach

- [ ] Change `-h` for `--hash` to `-t`

## 🧪 How to Test

Run 

```
wallet chain-info transaction -t f96fc75a5de2f4f00b851831a25cea77f06f84c20debceb09596dd103a502316
```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
