### PR TITLE
fix: install cargo-nextest with locked option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
         run: rustup install
 
       - name: Install nextest
-        run: cargo install cargo-nextest
+        run: cargo install --locked cargo-nextest
 
       - name: Run tests
         env:


### PR DESCRIPTION
## 🎯 Purpose

Fixes error while installing cargo-nextest in CI

## ⚙️ Approach

Used `--locked` as [suggested](https://github.com/nextest-rs/nextest/issues/2990#issuecomment-3797341068) by the author

## 🧪 How to Test

Just see CI

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
