### PR TITLE
Update bytes to v1.11.1 (RUSTSEC-2026-0007)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1112,9 +1112,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 dependencies = [
  "serde",
 ]
@@ -1673,7 +1673,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 2.0.114",
+ "syn 1.0.109",
 ]
 
 [[package]]


### PR DESCRIPTION
## 🎯 Purpose

Update bytes to the version that patches the vulnerability RUSTSEC-2026-0007

## ⚙️ Approach

Run `cargo update -p bytes` and commit the changes to `Cargo.lock`

## 🧪 How to Test

`cargo deny check` should pass

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
