### PR TITLE
chore: add label to zsh auto-completion

### DIFF
--- a/completions/zsh/_wallet
+++ b/completions/zsh/_wallet
@@ -150,10 +150,11 @@ _wallet_account() {
         subcommand)
             subcommands=(
                 'get:Get account data'
-                'list:List all accounts'
+                'list:List all accounts owned by the wallet'
                 'ls:List all accounts (alias for list)'
                 'new:Produce new public or private account'
                 'sync-private:Sync private accounts'
+                'label:Set a label for an account'
                 'help:Print this message or the help of the given subcommand(s)'
             )
             _describe -t subcommands 'account subcommands' subcommands
@@ -183,6 +184,11 @@ _wallet_account() {
                                 '--cci[Chain index of a parent node]:chain_index:'
                             ;;
                     esac
+                    ;;
+                label)
+                    _arguments \
+                        '(-a --account-id)'{-a,--account-id}'[Account ID to label]:account_id:_wallet_account_ids' \
+                        '(-l --label)'{-l,--label}'[The label to assign to the account]:label:'
                     ;;
             esac
             ;;


### PR DESCRIPTION
## 🎯 Purpose

Update zsh auto-completion script with latest changes.

## ⚙️ Approach

- [x] Add `account label` support to zsh auto-completion

## 🧪 How to Test

1. `cd completions/zsh`
2. `cp _wallet ~/.oh-my-zsh/custom/plugins/wallet/`
3. `wallet account la<TAB>`

## 🔗 Dependencies

None

## 🔜 Future Work

Add completion scripts for bash and other popular shells.

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- ~~[ ] Add/update tests~~
- ~~[ ] Add/update documentation and inline comments~~
