### PR TITLE
chore: document `NSSA_WALLET_HOME_DIR` in wallet tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,12 @@ Some completion scripts exists, see the [completions](./completions/README.md) f
 
 This tutorial walks you through creating accounts and executing NSSA programs in both public and private contexts.
 
+Before starting, make sure to set the wallet home directory so the CLI can find its configuration:
+
+```bash
+export NSSA_WALLET_HOME_DIR=$(pwd)/wallet/configs/debug
+```
+
 > [!NOTE]
 > The NSSA state is split into two separate but interconnected components: the public state and the private state.
 > The public state is an on-chain, publicly visible record of accounts indexed by their Account IDs


### PR DESCRIPTION
## 🎯 Purpose
Document the required `NSSA_WALLET_HOME_DIR` environment variable in the wallet tutorial section of the README.

## ⚙️ Approach
Add an `export NSSA_WALLET_HOME_DIR=$(pwd)/wallet/configs/debug` instruction at the start of the tutorial, before the health-check step. Without this, the wallet CLI cannot locate its configuration and fails silently.

## 🧪 How to Test
Follow the wallet tutorial from the README — the new instruction should appear before the health-check step.

## 🔗 Dependencies
None

## 📋 PR Completion Checklist
- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments