### PR TITLE
chore: increase wallet polling timeout for bedrock latency

### DIFF
--- a/wallet/configs/debug/wallet_config.json
+++ b/wallet/configs/debug/wallet_config.json
@@ -1,9 +1,9 @@
 {
   "override_rust_log": null,
   "sequencer_addr": "http://127.0.0.1:3040",
-  "seq_poll_timeout_millis": 12000,
-  "seq_tx_poll_max_blocks": 5,
-  "seq_poll_max_retries": 5,
+  "seq_poll_timeout_millis": 30000,
+  "seq_tx_poll_max_blocks": 15,
+  "seq_poll_max_retries": 10,
   "seq_block_poll_max_amount": 100,
   "initial_accounts": [
     {


### PR DESCRIPTION
## 🎯 Purpose
Fix spurious "Transaction not found in preconfigured amount of blocks" errors during public-to-public transfers.

## ⚙️ Approach
Increase polling parameters in `wallet/configs/debug/wallet_config.json`:
- `seq_poll_timeout_millis`: 12000 → 30000
- `seq_tx_poll_max_blocks`: 5 → 15
- `seq_poll_max_retries`: 5 → 10

The bedrock integration introduces additional latency in block confirmation. The previous values were too tight, causing the wallet to report errors even though transactions actually succeeded on-chain.

## 🧪 How to Test
1. Start the logos-blockchain node, indexer, and sequencer
2. Run `wallet auth-transfer send` between two public accounts
3. The command should no longer return a timeout error

## 🔗 Dependencies
None

## 📋 PR Completion Checklist
- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments