### PR TITLE
fix(sequencer_rpc): add AMM program id

### DIFF
--- a/sequencer_rpc/src/process.rs
+++ b/sequencer_rpc/src/process.rs
@@ -292,6 +292,7 @@ impl<BC: BlockSettlementClientTrait, IC: IndexerClientTrait> JsonHandler<BC, IC>
         );
         program_ids.insert("token".to_string(), Program::token().id());
         program_ids.insert("pinata".to_string(), Program::pinata().id());
+        program_ids.insert("amm".to_string(), Program::amm().id());
         program_ids.insert(
             "privacy_preserving_circuit".to_string(),
             nssa::PRIVACY_PRESERVING_CIRCUIT_ID,

--- a/wallet/src/cli/mod.rs
+++ b/wallet/src/cli/mod.rs
@@ -139,6 +139,12 @@ pub async fn execute_subcommand(
             if circuit_id != &nssa::PRIVACY_PRESERVING_CIRCUIT_ID {
                 panic!("Local ID for privacy preserving circuit is different from remote");
             }
+            let Some(amm_id) = remote_program_ids.get("amm") else {
+                panic!("Missing AMM program ID from remote");
+            };
+            if amm_id != &Program::amm().id() {
+                panic!("Local ID for AMM program is different from remote");
+            }
 
             println!("✅All looks good!");
 


### PR DESCRIPTION
This adds the AMM program ID to the `get_program_ids` RPC endpoints, as it's currently missing while still being predeployed.
