### PR TITLE
feat(nssa): support NSSA_ARTIFACTS_DIR env var in build.rs

### DIFF
--- a/nssa/build.rs
+++ b/nssa/build.rs
@@ -5,7 +5,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);
     let mod_dir = out_dir.join("program_methods");
     let mod_file = mod_dir.join("mod.rs");
-    let program_methods_dir = manifest_dir.join("../artifacts/program_methods/");
+    // Allow overriding the artifacts directory via environment variable.
+    // This is needed for reproducible/sandboxed builds (e.g., Nix) where the
+    // default relative path may resolve to a read-only location.
+    let program_methods_dir = env::var("NSSA_ARTIFACTS_DIR")
+        .map(|d| PathBuf::from(d).join("program_methods"))
+        .unwrap_or_else(|_| manifest_dir.join("../artifacts/program_methods/"));
 
     println!("cargo:rerun-if-changed={}", program_methods_dir.display());
 


### PR DESCRIPTION
## 🎯 Purpose

Allow overriding the artifacts directory path in `nssa/build.rs` via the `NSSA_ARTIFACTS_DIR` environment variable. Without this, the hardcoded relative path breaks reproducible/sandboxed builds (Nix, Docker) where the crate is vendored into a read-only location or the working directory differs.

## ⚙️ Approach

- Check for `NSSA_ARTIFACTS_DIR` env var in `build.rs`; fall back to the existing hardcoded relative path if unset
- No behavioural change for existing workflows — fully backwards compatible

## 🧪 How to Test

```bash
# Standard build — unchanged behaviour
cargo build -p nssa

# Override artifacts dir
NSSA_ARTIFACTS_DIR=/path/to/artifacts cargo build -p nssa
```

## 🔗 Dependencies

None.

## 🔜 Future Work

- Could be extended to support other build.rs path overrides for full Nix hermetic builds

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments