### PR TITLE
Compress R0 proofs

### DIFF
--- a/nssa/src/privacy_preserving_transaction/circuit.rs
+++ b/nssa/src/privacy_preserving_transaction/circuit.rs
@@ -7,7 +7,7 @@ use nssa_core::{
     account::AccountWithMetadata,
     program::{ChainedCall, InstructionData, ProgramId, ProgramOutput},
 };
-use risc0_zkvm::{ExecutorEnv, InnerReceipt, Receipt, default_prover};
+use risc0_zkvm::{ExecutorEnv, InnerReceipt, ProverOpts, Receipt, default_prover};
 
 use crate::{
     error::NssaError,
@@ -126,8 +126,9 @@ pub fn execute_and_prove(
     env_builder.write(&circuit_input).unwrap();
     let env = env_builder.build().unwrap();
     let prover = default_prover();
+    let opts = ProverOpts::succinct();
     let prove_info = prover
-        .prove(env, PRIVACY_PRESERVING_CIRCUIT_ELF)
+        .prove_with_opts(env, PRIVACY_PRESERVING_CIRCUIT_ELF, &opts)
         .map_err(|e| NssaError::CircuitProvingError(e.to_string()))?;
 
     let proof = Proof(borsh::to_vec(&prove_info.receipt.inner)?);


### PR DESCRIPTION
## 🎯 Purpose

Compress Risc0 proofs to get ~200kb proofs.

## ⚙️ Approach

Use the succinct prover opts provided by R0

## 🧪 How to Test

Existing tests should pass.

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality