### PR TITLE
fix(examples): make tail call example programs work again

### DIFF
--- a/examples/program_deployment/methods/guest/src/bin/simple_tail_call.rs
+++ b/examples/program_deployment/methods/guest/src/bin/simple_tail_call.rs
@@ -14,7 +14,7 @@ use nssa_core::program::{
 /// `cargo risczero build --manifest-path examples/program_deployment/methods/guest/Cargo.toml`
 /// This compiles the programs and outputs the IDs in hex that can be used to copy here.
 const HELLO_WORLD_PROGRAM_ID_HEX: &str =
-    "e9dfc5a5d03c9afa732adae6e0edfce4bbb44c7a2afb9f148f4309917eb2de6f";
+    "075d33a4ffe411d14df68194c0d4a416abed564b3eb788649cabeb730f393258";
 
 fn hello_world_program_id() -> ProgramId {
     let hello_world_program_id_bytes: [u8; 32] = hex::decode(HELLO_WORLD_PROGRAM_ID_HEX)

--- a/examples/program_deployment/methods/guest/src/bin/tail_call_with_pda.rs
+++ b/examples/program_deployment/methods/guest/src/bin/tail_call_with_pda.rs
@@ -17,7 +17,7 @@ use nssa_core::program::{
 // account is passed along but marked with `is_authorized = true`.
 
 const HELLO_WORLD_WITH_AUTHORIZATION_PROGRAM_ID_HEX: &str =
-    "1d95c761168a7fa62eb15a3cc74d3f075e6ec98e6c1ac25bd5bcc7e0a9426398";
+    "60a0cc3d560cba06ba65f02ca70db7828e448a15f320eb7d0fd48e7fb1fa5a3e";
 const PDA_SEED: PdaSeed = PdaSeed::new([37; 32]);
 
 fn hello_world_program_id() -> ProgramId {


### PR DESCRIPTION
These programs have been referencing incorrect program IDs, resulting in "Unknown program" errors when trying to run them.

This commit fixes the IDs based on the latest source. Ideally this should be fixed by making the program IDs configurable.

