### PR TITLE
chore(ci): adopt conventional commits and auto-generated changelog

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,26 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            test
+            refactor
+            perf
+            build
+            ci
+            revert
+          requireScope: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,49 @@
+name: Release
+
+on:
+  push:
+    tags: ['v*']
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate this-release section
+        uses: orhun/git-cliff-action@v3
+        id: cliff_latest
+        with:
+          config: cliff.toml
+          args: --latest --strip header
+
+      - name: Generate full CHANGELOG.md
+        uses: orhun/git-cliff-action@v3
+        with:
+          config: cliff.toml
+          args: --output CHANGELOG.md
+
+      - name: Commit CHANGELOG.md to main
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git fetch origin main
+          git checkout main
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog changes"
+          else
+            git commit -m "chore: update CHANGELOG.md for ${{ github.ref_name }}"
+            git push origin main
+          fi
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          body: ${{ steps.cliff_latest.outputs.content }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,15 @@
+# Contributing
+
+## Commit message format
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/). Pull request titles must match `type(scope): description`, or `type(scope)!: description` for breaking changes. Allowed types: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `perf`, `build`, `ci`, `revert`.
+
+PR titles are checked by `.github/workflows/pr-title.yml` and used as the squash-merge commit subject, so the `main` branch log stays conventional by construction.
+
+Breaking changes are flagged with `!` after the type/scope, optionally with a `BREAKING CHANGE:` footer in the PR body describing the migration. `CHANGELOG.md` is auto-generated from these markers on every `v*` tag via `git-cliff`, and a GitHub Release is created with the same content.
+
+Examples:
+
+- `feat(nssa): add private PDA support`
+- `fix(wallet): correct fee calculation`
+- `feat(nssa)!: rename AccountId::from((prog, seed)) to AccountId::for_public_pda`

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,43 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+body = """
+{% if version %}\
+## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+## [Unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+### {{ group | upper_first }}
+{% for commit in commits %}\
+- {% if commit.breaking %}**[BREAKING]** {% endif %}{{ commit.message | upper_first }}\
+{% if commit.breaking and commit.breaking_description %} ({{ commit.breaking_description }}){% endif %}
+{% endfor %}\
+{% endfor %}
+"""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Bug Fixes" },
+  { message = "^perf", group = "Performance" },
+  { message = "^refactor", group = "Refactor" },
+  { message = "^docs", group = "Documentation" },
+  { message = "^test", group = "Testing" },
+  { message = "^build", group = "Build" },
+  { message = "^ci", group = "CI" },
+  { message = "^chore", skip = true },
+  { message = "^revert", group = "Revert" },
+]
+filter_commits = false
+tag_pattern = "v[0-9]*"
+sort_commits = "newest"


### PR DESCRIPTION
## 🎯 Purpose

Currently breaking changes ship without explicit communication, so downstream consumers (notably the LEZ programs in the separate repo) discover them at build time. This PR adopts Conventional Commits + auto-generated CHANGELOG.md so each release surfaces breaking changes in a single, parseable place.

## ⚙️ Approach

- [x] Add `cliff.toml` (`git-cliff` config) at repo root, grouping commits by type with breaking changes flagged via `**[BREAKING]**`.
- [x] Add `.github/workflows/pr-title.yml`, enforcing Conventional Commit PR titles via `amannn/action-semantic-pull-request@v5`. Combined with squash-merge + PR-title-as-subject, the `main` log stays conventional by construction.
- [x] Add `.github/workflows/release.yml`, firing on `v*` tag push: generates the latest-section markdown, regenerates `CHANGELOG.md`, commits it back to `main`, and creates a GitHub Release with the new section.
- [x] Add `CONTRIBUTING.md` documenting the format, allowed types, and the breaking-change marker conventions.

## 🧪 How to Test

- Push a non-conventional PR title on a throwaway branch and confirm the new `PR Title` check fails. Rename to a conventional title and confirm it passes.
- After this lands, push a test tag `v0.0.0-test` on a side branch (or trigger via `workflow_dispatch`) and confirm `CHANGELOG.md` regenerates and a GitHub Release is created with the latest-section content.
- Confirm the Releases page surfaces breaking-change entries (e.g. mark a follow-up commit with `feat(scope)!:` and verify it shows under `[BREAKING]`).

## 🔗 Dependencies

N/A.

## 🔜 Future Work

- Repo setting: enforce squash-merge with PR title as commit subject (out-of-tree GitHub setting, not a code change).
- Adopt `cargo-release` to automate version bumps + tag pushes per workspace crate.
- Backfill `CHANGELOG.md` for the previous release that included PR #446 (manual one-shot, then auto-generated from this point on).

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [x] Add/update documentation and inline comments