### PR TITLE
Add getAccountAtBlock RPC to indexer

### DIFF
--- a/indexer/core/src/block_store.rs
+++ b/indexer/core/src/block_store.rs
@@ -135,6 +135,12 @@ impl IndexerStore {
             .get_account_by_id(*account_id))
     }
 
+    pub fn account_state_at_block(&self, account_id: &AccountId, block_id: u64) -> Result<Account> {
+        Ok(self
+            .get_state_at_block(block_id)?
+            .get_account_by_id(*account_id))
+    }
+
     pub async fn put_block(&self, mut block: Block, l1_header: HeaderId) -> Result<()> {
         {
             let mut state_guard = self.current_state.write().await;
@@ -276,5 +282,65 @@ mod tests {
 
         assert_eq!(acc1_val.balance, 9920);
         assert_eq!(acc2_val.balance, 20080);
+    }
+
+    #[tokio::test]
+    async fn account_state_at_block() {
+        let home = tempdir().unwrap();
+
+        let storage = IndexerStore::open_db_with_genesis(
+            home.as_ref(),
+            &genesis_block(),
+            &nssa::V03State::new_with_genesis_accounts(
+                &[(acc1(), 10000), (acc2(), 20000)],
+                vec![],
+                0,
+            ),
+        )
+        .unwrap();
+
+        let mut prev_hash = genesis_block().header.hash;
+
+        let from = acc1();
+        let to = acc2();
+        let sign_key = acc1_sign_key();
+
+        for i in 2..10 {
+            let tx = common::test_utils::create_transaction_native_token_transfer(
+                from,
+                i - 2,
+                to,
+                10,
+                &sign_key,
+            );
+            let block_id = u64::try_from(i).unwrap();
+
+            let next_block =
+                common::test_utils::produce_dummy_block(block_id, Some(prev_hash), vec![tx]);
+            prev_hash = next_block.header.hash;
+
+            storage
+                .put_block(next_block, HeaderId::from([u8::try_from(i).unwrap(); 32]))
+                .await
+                .unwrap();
+        }
+
+        // Genesis block: no transfers applied yet.
+        let acc1_at_1 = storage.account_state_at_block(&acc1(), 1).unwrap();
+        let acc2_at_1 = storage.account_state_at_block(&acc2(), 1).unwrap();
+        assert_eq!(acc1_at_1.balance, 10000);
+        assert_eq!(acc2_at_1.balance, 20000);
+
+        // After block 5: 4 transfers of 10 applied (one each in blocks 2..=5).
+        let acc1_at_5 = storage.account_state_at_block(&acc1(), 5).unwrap();
+        let acc2_at_5 = storage.account_state_at_block(&acc2(), 5).unwrap();
+        assert_eq!(acc1_at_5.balance, 9960);
+        assert_eq!(acc2_at_5.balance, 20040);
+
+        // After final block 9: 8 transfers applied; should match current state.
+        let acc1_at_9 = storage.account_state_at_block(&acc1(), 9).unwrap();
+        let acc2_at_9 = storage.account_state_at_block(&acc2(), 9).unwrap();
+        assert_eq!(acc1_at_9.balance, 9920);
+        assert_eq!(acc2_at_9.balance, 20080);
     }
 }

--- a/indexer/service/rpc/src/lib.rs
+++ b/indexer/service/rpc/src/lib.rs
@@ -41,6 +41,13 @@ pub trait Rpc {
     #[method(name = "getAccount")]
     async fn get_account(&self, account_id: AccountId) -> Result<Account, ErrorObjectOwned>;
 
+    #[method(name = "getAccountAtBlock")]
+    async fn get_account_at_block(
+        &self,
+        account_id: AccountId,
+        block_id: BlockId,
+    ) -> Result<Account, ErrorObjectOwned>;
+
     #[method(name = "getTransaction")]
     async fn get_transaction(
         &self,

--- a/indexer/service/src/mock_service.rs
+++ b/indexer/service/src/mock_service.rs
@@ -239,6 +239,22 @@ impl indexer_service_rpc::RpcServer for MockIndexerService {
             .ok_or_else(|| ErrorObjectOwned::owned(-32001, "Account not found", None::<()>))
     }
 
+    async fn get_account_at_block(
+        &self,
+        account_id: AccountId,
+        _block_id: BlockId,
+    ) -> Result<Account, ErrorObjectOwned> {
+        // Mock service does not track historical state; returns current state regardless of
+        // block_id.
+        self.state
+            .read()
+            .await
+            .accounts
+            .get(&account_id)
+            .cloned()
+            .ok_or_else(|| ErrorObjectOwned::owned(-32001, "Account not found", None::<()>))
+    }
+
     async fn get_transaction(
         &self,
         tx_hash: HashType,

--- a/indexer/service/src/service.rs
+++ b/indexer/service/src/service.rs
@@ -83,6 +83,19 @@ impl indexer_service_rpc::RpcServer for IndexerService {
             .into())
     }
 
+    async fn get_account_at_block(
+        &self,
+        account_id: AccountId,
+        block_id: BlockId,
+    ) -> Result<Account, ErrorObjectOwned> {
+        Ok(self
+            .indexer
+            .store
+            .account_state_at_block(&account_id.into(), block_id)
+            .map_err(db_error)?
+            .into())
+    }
+
     async fn get_transaction(
         &self,
         tx_hash: HashType,


### PR DESCRIPTION
## 🎯 Purpose

Here's the draft PR as promised @Arjentix.

The indexer's public RPC currently exposes only *current* account state via `getAccount` — there's no way to query an account's state at a historical block. This PR adds `getAccountAtBlock` to close that gap.

The internal capability already exists (`BlockStore::get_state_at_block` reconstructs the public state at any block); this PR just plumbs it through to the public RPC surface in a per-account-shaped query, following your preference for `getAccountAtBlock`-style methods over a bulk `getStateAtBlock` that returns raw `V03State`.

The new method is broadly useful for explorers, analytics, and any consumer reasoning about historical account state.

## ⚙️ Approach

A new RPC method on the indexer that, for a given `(account_id, block_id)`, reconstructs the public state at `block_id` (via the existing `BlockStore::get_state_at_block`) and returns the looked-up `Account` — a default `Account` is returned for ids not present in the public state at that block, matching the behavior of `V03State::get_account_by_id`.

- [x] Add `getAccountAtBlock` to the indexer RPC trait (`indexer/service/rpc/src/lib.rs`)
- [x] Implement on `IndexerService` (`indexer/service/src/service.rs`)
- [x] Implement on `MockIndexerService` — returns current state regardless of `block_id` (`indexer/service/src/mock_service.rs`)
- [x] Add `account_state_at_block` helper on `IndexerStore`, parallel to the existing `account_current_state` (`indexer/core/src/block_store.rs`)
- [x] Add unit test exercising historical balance lookups across genesis, mid-chain, and tip blocks

**Performance note:** the implementation is intentionally naive — each call reconstructs the full `V03State` at the requested block, then indexes by `AccountId`. This was previously not a use case the indexer was tuned for, so there's no per-account historical side index to lean on.

## 🧪 How to Test

Run the new unit test alongside the existing block-store tests:

```sh
RISC0_DEV_MODE=1 cargo nextest run -p indexer_core block_store::tests
```

Expected: 3 tests pass — `correct_startup`, `state_transition`, and the new `account_state_at_block`. The new test builds a chain with native-token transfers across 8 blocks and asserts that historical balance lookups at genesis, mid-chain (block 5), and tip (block 9) return the correct values.

End-to-end RPC verification (manual, optional):
1. Run an indexer service locally that has at least a few blocks with state changes.
2. JSON-RPC `getAccountAtBlock` with `(account_id, block_id)` of an account whose state is known to have changed.
3. Confirm the returned `Account` matches the expected historical state.

## 🔗 Dependencies

None.

## 🔜 Future Work

Intentionally out of scope for this PR; happy to follow up if there's appetite:

- Performance: a per-account state side index (mirroring the `(account_id → tx_list)` index that backs `getTransactionsByAccount`) would turn the current O(N) state reconstruction into an O(log) read.
- A `getAccountsAtBlock(account_ids: Vec<AccountId>, block_id)` batch variant — useful for snapshot workflows that walk many accounts at the same block; lets a single state reconstruction serve many lookups.
- A `getAccountAtBlockHash(account_id, block_hash)` variant parallel to `getBlockByHash` if hash-based block addressing is wanted on this query.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
