### PR TITLE
fix: Private shared account preparation

### DIFF
--- a/integration_tests/tests/shared_accounts.rs
+++ b/integration_tests/tests/shared_accounts.rs
@@ -155,7 +155,6 @@ async fn group_invite_join_key_agreement() -> Result<()> {
 /// Fund a shared account from a public account via auth-transfer, then sync.
 /// TODO: Requires auth-transfer init to work with shared accounts (authorization flow).
 #[test]
-#[ignore = "Requires auth-transfer init to work with shared accounts (authorization flow)"]
 async fn fund_shared_account_from_public() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
@@ -189,6 +188,10 @@ async fn fund_shared_account_from_public() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+
+    // Sync private accounts
+    let command = Command::Account(AccountSubcommand::SyncPrivate);
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Fund from a public account
     let from_public = ctx.existing_public_accounts()[0];

--- a/key_protocol/src/key_protocol_core/mod.rs
+++ b/key_protocol/src/key_protocol_core/mod.rs
@@ -178,6 +178,7 @@ impl NSSAUserData {
     }
 
     /// Returns the key chain and account data for the given private account ID.
+    /// Does not cover shared private accounts — use `shared_private_account` for those.
     #[must_use]
     pub fn get_private_account(
         &self,

--- a/wallet/src/lib.rs
+++ b/wallet/src/lib.rs
@@ -505,8 +505,17 @@ impl WalletCore {
 
     #[must_use]
     pub fn get_private_account_commitment(&self, account_id: AccountId) -> Option<Commitment> {
-        let (_keys, account, _identifier) =
-            self.storage.user_data.get_private_account(account_id)?;
+        let account = self
+            .storage
+            .user_data
+            .get_private_account(account_id)
+            .map(|(_keys, account, _identifier)| account)
+            .or_else(|| {
+                self.storage
+                    .user_data
+                    .shared_private_account(&account_id)
+                    .map(|entry| entry.account.clone())
+            })?;
         Some(Commitment::new(&account_id, &account))
     }
 

--- a/wallet/src/privacy_preserving_tx.rs
+++ b/wallet/src/privacy_preserving_tx.rs
@@ -381,24 +381,18 @@ async fn private_shared_acc_preparation(
         .map(|e| e.account.clone())
         .unwrap_or_default();
 
-    let exists = acc != nssa_core::account::Account::default();
-    let pre_state = AccountWithMetadata::new(acc, exists, account_id);
+    let pre_state = AccountWithMetadata::new(acc, true, account_id);
 
-    let proof = if exists {
-        wallet
-            .check_private_account_initialized(account_id)
-            .await
-            .unwrap_or(None)
-    } else {
-        None
-    };
+    let proof = wallet
+        .check_private_account_initialized(account_id)
+        .await
+        .unwrap_or(None);
 
     let eph_holder = EphemeralKeyHolder::new(&npk);
     let ssk = eph_holder.calculate_shared_secret_sender(&vpk);
     let epk = eph_holder.generate_ephemeral_public_key();
-
     Ok(AccountPreparedData {
-        nsk: exists.then_some(nsk),
+        nsk: Some(nsk),
         npk,
         identifier,
         vpk,


### PR DESCRIPTION
## 🎯 Purpose

Fixes a bug where shared private accounts were incorrectly treated as non-existent during transaction preparation when their local state was empty. This caused private transactions involving shared accounts to fail or produce incorrect proofs.

## ⚙️ Approach

- Fix private_shared_acc_preparation to always set exists = true and always include the nsk key, regardless of whether the local account state is populated yet.
- Fix get_private_account_commitment to look up shared private accounts in addition to regular private accounts.
- Add a comment to get_private_account clarifying it does not cover shared private accounts.
- Enable the previously ignored fund_shared_account_from_public integration test and add a private account sync step before funding.

## 🧪 How to Test

Run the integration test that was previously ignored:

`RISC0_DEV_MODE=1 cargo nextest run -p integration_tests fund_shared_account_from_public`

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
