### PR TITLE
ci: add bench-regression workflow for crypto_primitives_bench

### DIFF
--- a/.github/workflows/bench-regression.yml
+++ b/.github/workflows/bench-regression.yml
@@ -1,0 +1,44 @@
+on:
+  pull_request:
+    paths:
+      - "tools/crypto_primitives_bench/**"
+      - "key_protocol/**"
+      - "nssa/core/**"
+      - ".github/workflows/bench-regression.yml"
+
+permissions:
+  contents: read
+  pull-requests: write
+
+name: bench-regression
+
+jobs:
+  crypto-primitives:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
+          # criterion-compare-action checks out the base branch in a second
+          # working tree, so we need the full history.
+          fetch-depth: 0
+
+      - uses: ./.github/actions/install-system-deps
+
+      - uses: ./.github/actions/install-risc0
+
+      - uses: ./.github/actions/install-logos-blockchain-circuits
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install active toolchain
+        run: rustup install
+
+      - name: Run criterion-compare against base branch
+        uses: boa-dev/criterion-compare-action@v3
+        with:
+          branchName: ${{ github.base_ref }}
+          cwd: tools/crypto_primitives_bench
+          benchName: primitives
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 🎯 Purpose

Add a `bench-regression` GitHub workflow that uses `boa-dev/criterion-compare-action` to gate `crypto_primitives_bench` against the base branch on every PR that touches the watched paths. Follow-up to #488 (the criterion migration); deferred to this PR because the action needs the criterion bench to exist on both head and base.

## ⚙️ Approach

Workflow triggers on PRs touching `tools/crypto_primitives_bench/**`, `key_protocol/**`, `nssa/core/**`, or the workflow file itself. One job runs the action against the PR base, with `cwd: tools/crypto_primitives_bench` and `benchName: primitives`. The action posts the comparison as a PR comment.

- [x] Add `.github/workflows/bench-regression.yml`.

## 🧪 How to Test

Open this PR; the workflow self-triggers because it touches the watched path (the workflow file itself). The first run on this PR will compare against main and post a no-change diff (since this PR doesn't touch bench code).

## 🔗 Dependencies

#488 merged. Main now has `tools/crypto_primitives_bench/benches/primitives.rs` for the action to compare against.

## 🔜 Future Work

None.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
