### PR TITLE
feat(ci): speed up ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,9 +132,48 @@ jobs:
           RUST_LOG: "info"
         run: cargo nextest run --workspace --exclude integration_tests --all-features
 
+  integration-test-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.discover.outputs.targets }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
+
+      - name: Discover integration test targets
+        id: discover
+        run: |
+          declare -a targets=()
+
+          for path in integration_tests/tests/*; do
+            if [[ -f "$path" && "$path" == *.rs ]]; then
+              targets+=("$(basename "$path" .rs)")
+            elif [[ -d "$path" && -f "$path/main.rs" ]]; then
+              targets+=("$(basename "$path")")
+            fi
+          done
+
+          if [[ "${#targets[@]}" -eq 0 ]]; then
+            echo "No integration test targets were discovered." >&2
+            exit 1
+          fi
+
+          mapfile -t targets < <(printf '%s\n' "${targets[@]}" | sort -u)
+          targets_json="$(printf '%s\n' "${targets[@]}" | jq -R . | jq -cs .)"
+
+          echo "targets=$targets_json" >> "$GITHUB_OUTPUT"
+          echo "Discovered integration targets: $targets_json"
+
   integration-tests:
+    needs: integration-test-targets
     runs-on: ubuntu-latest
     timeout-minutes: 90 # TODO: Apply CI cache to speed this up
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.integration-test-targets.outputs.targets) }}
+    name: integration-tests (${{ matrix.target }})
     steps:
       - uses: actions/checkout@v5
         with:
@@ -158,7 +197,12 @@ jobs:
         env:
           RISC0_DEV_MODE: "1"
           RUST_LOG: "info"
-        run: cargo nextest run -p integration_tests -- --skip tps_test
+        run: |
+          if [[ "${{ matrix.target }}" == "tps" ]]; then
+            cargo nextest run -p integration_tests --test "${{ matrix.target }}" -- --skip tps_test
+          else
+            cargo nextest run -p integration_tests --test "${{ matrix.target }}"
+          fi
 
   valid-proof-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,12 @@ jobs:
       - name: Install active toolchain
         run: rustup install
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-rust-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Lint workspace
         env:
           RISC0_SKIP_BUILD: "1"
@@ -122,6 +128,12 @@ jobs:
 
       - name: Install active toolchain
         run: rustup install
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-rust-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install nextest
         run: cargo install --locked cargo-nextest
@@ -190,6 +202,12 @@ jobs:
       - name: Install active toolchain
         run: rustup install
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-rust-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Install nextest
         run: cargo install --locked cargo-nextest
 
@@ -223,6 +241,12 @@ jobs:
       - name: Install active toolchain
         run: rustup install
 
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-rust-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+
       - name: Test valid proof
         env:
           RUST_LOG: "info"
@@ -239,6 +263,12 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
 
       - uses: ./.github/actions/install-risc0
+
+      - name: Restore Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: ci-rust-cache
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Install just
         run: cargo install --locked just

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,48 +144,10 @@ jobs:
           RUST_LOG: "info"
         run: cargo nextest run --workspace --exclude integration_tests --all-features
 
-  integration-test-targets:
+  integration-tests-prebuild:
     runs-on: ubuntu-latest
     outputs:
-      targets: ${{ steps.discover.outputs.targets }}
-    steps:
-      - uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
-
-      - name: Discover integration test targets
-        id: discover
-        run: |
-          declare -a targets=()
-
-          for path in integration_tests/tests/*; do
-            if [[ -f "$path" && "$path" == *.rs ]]; then
-              targets+=("$(basename "$path" .rs)")
-            elif [[ -d "$path" && -f "$path/main.rs" ]]; then
-              targets+=("$(basename "$path")")
-            fi
-          done
-
-          if [[ "${#targets[@]}" -eq 0 ]]; then
-            echo "No integration test targets were discovered." >&2
-            exit 1
-          fi
-
-          mapfile -t targets < <(printf '%s\n' "${targets[@]}" | sort -u)
-          targets_json="$(printf '%s\n' "${targets[@]}" | jq -R . | jq -cs .)"
-
-          echo "targets=$targets_json" >> "$GITHUB_OUTPUT"
-          echo "Discovered integration targets: $targets_json"
-
-  integration-tests:
-    needs: integration-test-targets
-    runs-on: ubuntu-latest
-    timeout-minutes: 90 # TODO: Apply CI cache to speed this up
-    strategy:
-      fail-fast: false
-      matrix:
-        target: ${{ fromJson(needs.integration-test-targets.outputs.targets) }}
-    name: integration-tests (${{ matrix.target }})
+      targets: ${{ steps.discover-targets.outputs.targets }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -211,16 +173,74 @@ jobs:
       - name: Install nextest
         run: cargo install --locked cargo-nextest
 
+      - name: Build integration test archive
+        env:
+          RISC0_DEV_MODE: "1"
+        run: cargo nextest archive -p integration_tests --archive-file integration-tests.tar.zst --no-pager
+
+      - name: Upload integration test archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-tests-archive
+          path: integration-tests.tar.zst
+
+      - name: Discover integration test targets from archive
+        id: discover-targets
+        run: |
+          cargo nextest list \
+            --archive-file integration-tests.tar.zst \
+            --list-type binaries-only \
+            --message-format json \
+            --no-pager > integration-tests-binaries.json
+
+          targets_json="$(jq -c '[."rust-binaries" | to_entries[] | select(.value.kind == "test" and .value."binary-name" != "tps") | .value."binary-name"] | sort | unique' integration-tests-binaries.json)"
+
+          if [[ "$targets_json" == "[]" ]]; then
+            echo "No integration test targets were discovered." >&2
+            exit 1
+          fi
+
+          echo "targets=$targets_json" >> "$GITHUB_OUTPUT"
+          echo "Discovered integration targets: $targets_json"
+
+  integration-tests:
+    needs: integration-tests-prebuild
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.integration-tests-prebuild.outputs.targets) }}
+    name: integration-tests (${{ matrix.target }})
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.head_ref }}
+
+      - uses: ./.github/actions/install-system-deps
+
+      - uses: ./.github/actions/install-risc0
+
+      - uses: ./.github/actions/install-logos-blockchain-circuits
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install active toolchain
+        run: rustup install
+
+      - name: Download integration test archive
+        uses: actions/download-artifact@v4
+        with:
+          name: integration-tests-archive
+
+      - name: Install nextest
+        run: cargo install --locked cargo-nextest
+
       - name: Run tests
         env:
           RISC0_DEV_MODE: "1"
           RUST_LOG: "info"
-        run: |
-          if [[ "${{ matrix.target }}" == "tps" ]]; then
-            cargo nextest run -p integration_tests --test "${{ matrix.target }}" -- --skip tps_test
-          else
-            cargo nextest run -p integration_tests --test "${{ matrix.target }}"
-          fi
+        run: cargo nextest run --archive-file integration-tests.tar.zst -E "binary(${{ matrix.target }})"
 
   valid-proof-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## 🎯 Purpose

Speed up CI integration tests runs as they were significantly slowed down after the merge of genesis configuration

## ⚙️ Approach

- Cache rust artifacts. Cache is written only on main branch.
- Build integration tests binary once and then run parallel jobs per each module (excluding `tps` which we ignore)

## 🧪 How to Test

See CI

## 🔗 Dependencies

None

## 🔜 Future Work

Consider introducing Docker CI image to not to install same dependencies everytime (risc0, nextest, rust toolchain).

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
~- [ ] Add/update tests~
~- [ ] Add/update documentation and inline comments~
