### PR TITLE
chore(ci): pin circuits installation script to a commit

### DIFF
--- a/.github/actions/install-logos-blockchain-circuits/action.yaml
+++ b/.github/actions/install-logos-blockchain-circuits/action.yaml
@@ -16,4 +16,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
-        curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/main/scripts/setup-logos-blockchain-circuits.sh | bash
+        curl -sSL https://raw.githubusercontent.com/logos-blockchain/logos-blockchain/6ac348bea4160ca708b70a86b3964e9f1ce82fff/scripts/setup-logos-blockchain-circuits.sh | bash


### PR DESCRIPTION
## 🎯 Purpose

Our CI started failing after Logos Blockchain Team removed circuits from their master branch. In future we will update to this version of node and libraries. But for now this PR pins installation script to a specific commit.

## ⚙️ Approach

- Pin installation script to https://github.com/logos-blockchain/logos-blockchain/commit/6ac348bea4160ca708b70a86b3964e9f1ce82fff -- a commit just before purge of this script

## 🧪 How to Test

Just see CI

## 🔗 Dependencies

None

## 🔜 Future Work

Remove circuits installation and move to a new SDK

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
~- [ ] Add/update tests~
~- [ ] Add/update documentation and inline comments~
