### PR TITLE
fix!: remove redundant `msg_id` and `block_parent_id` from `common::Block` structs

### DIFF
--- a/lez/common/src/block.rs
+++ b/lez/common/src/block.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256, digest::FixedOutput as _};
 
 use crate::{HashType, transaction::LeeTransaction};
-pub type MantleMsgId = [u8; 32];
 pub type BlockHash = HashType;
 
 #[derive(Debug, Clone, BorshSerialize, BorshDeserialize)]
@@ -54,7 +53,6 @@ pub struct Block {
     pub header: BlockHeader,
     pub body: BlockBody,
     pub bedrock_status: BedrockStatus,
-    pub bedrock_parent_id: MantleMsgId,
 }
 
 impl Serialize for Block {
@@ -79,11 +77,7 @@ pub struct HashableBlockData {
 
 impl HashableBlockData {
     #[must_use]
-    pub fn into_pending_block(
-        self,
-        signing_key: &lee::PrivateKey,
-        bedrock_parent_id: MantleMsgId,
-    ) -> Block {
+    pub fn into_pending_block(self, signing_key: &lee::PrivateKey) -> Block {
         const PREFIX: &[u8; 32] = b"/LEE/v0.3/Message/Block/\x00\x00\x00\x00\x00\x00\x00\x00";
 
         let data_bytes = borsh::to_vec(&self).unwrap();
@@ -110,7 +104,6 @@ impl HashableBlockData {
                 transactions: self.transactions,
             },
             bedrock_status: BedrockStatus::Pending,
-            bedrock_parent_id,
         }
     }
 }

--- a/lez/common/src/block.rs
+++ b/lez/common/src/block.rs
@@ -12,7 +12,6 @@ pub type BlockHash = HashType;
 pub struct BlockMeta {
     pub id: BlockId,
     pub hash: BlockHash,
-    pub msg_id: MantleMsgId,
 }
 
 #[derive(Debug, Clone)]

--- a/lez/common/src/test_utils.rs
+++ b/lez/common/src/test_utils.rs
@@ -39,7 +39,7 @@ pub fn produce_dummy_block(
         transactions,
     };
 
-    block_data.into_pending_block(&sequencer_sign_key_for_testing(), [0; 32])
+    block_data.into_pending_block(&sequencer_sign_key_for_testing())
 }
 
 #[must_use]

--- a/lez/explorer_service/src/components/block_preview.rs
+++ b/lez/explorer_service/src/components/block_preview.rs
@@ -27,7 +27,6 @@ pub fn BlockPreview(block: Block) -> impl IntoView {
             },
         body: BlockBody { transactions },
         bedrock_status,
-        bedrock_parent_id: _,
     } = block;
 
     let tx_count = transactions.len();

--- a/lez/explorer_service/src/pages/block_page.rs
+++ b/lez/explorer_service/src/pages/block_page.rs
@@ -64,7 +64,6 @@ pub fn BlockPage() -> impl IntoView {
                                         transactions,
                                     },
                                     bedrock_status,
-                                    bedrock_parent_id: _,
                                 } = blk;
 
                                 let hash_str = hash.to_string();

--- a/lez/indexer/core/src/block_store.rs
+++ b/lez/indexer/core/src/block_store.rs
@@ -238,10 +238,8 @@ mod tests {
             timestamp: 0,
             transactions: vec![clock_tx],
         };
-        let genesis_block = genesis_block_data.into_pending_block(
-            &common::test_utils::sequencer_sign_key_for_testing(),
-            [0; 32],
-        );
+        let genesis_block = genesis_block_data
+            .into_pending_block(&common::test_utils::sequencer_sign_key_for_testing());
         let mut prev_hash = Some(genesis_block.header.hash);
         storage
             .put_block(genesis_block, HeaderId::from([0_u8; 32]))

--- a/lez/indexer/ffi/indexer_ffi.h
+++ b/lez/indexer/ffi/indexer_ffi.h
@@ -320,13 +320,10 @@ typedef struct FfiVec_FfiTransaction {
 
 typedef struct FfiVec_FfiTransaction FfiBlockBody;
 
-typedef struct FfiBytes32 FfiMsgId;
-
 typedef struct FfiBlock {
   struct FfiBlockHeader header;
   FfiBlockBody body;
   enum FfiBedrockStatus bedrock_status;
-  FfiMsgId bedrock_parent_id;
 } FfiBlock;
 
 typedef struct FfiOption_FfiBlock {

--- a/lez/indexer/ffi/src/api/types/block.rs
+++ b/lez/indexer/ffi/src/api/types/block.rs
@@ -1,9 +1,7 @@
-use indexer_service_protocol::{
-    BedrockStatus, Block, BlockHeader, HashType, MantleMsgId, Signature,
-};
+use indexer_service_protocol::{BedrockStatus, Block, BlockHeader, HashType, Signature};
 
 use crate::api::types::{
-    FfiBlockId, FfiHashType, FfiMsgId, FfiOption, FfiSignature, FfiTimestamp, FfiVec,
+    FfiBlockId, FfiHashType, FfiOption, FfiSignature, FfiTimestamp, FfiVec,
     transaction::free_ffi_transaction_vec, vectors::FfiBlockBody,
 };
 
@@ -12,7 +10,6 @@ pub struct FfiBlock {
     pub header: FfiBlockHeader,
     pub body: FfiBlockBody,
     pub bedrock_status: FfiBedrockStatus,
-    pub bedrock_parent_id: FfiMsgId,
 }
 
 impl From<Block> for FfiBlock {
@@ -21,7 +18,6 @@ impl From<Block> for FfiBlock {
             header,
             body,
             bedrock_status,
-            bedrock_parent_id,
         } = value;
 
         Self {
@@ -33,7 +29,6 @@ impl From<Block> for FfiBlock {
                 .collect::<Vec<_>>()
                 .into(),
             bedrock_status: bedrock_status.into(),
-            bedrock_parent_id: bedrock_parent_id.into(),
         }
     }
 }
@@ -126,8 +121,6 @@ pub unsafe extern "C" fn free_ffi_block(val: FfiBlock) {
     #[expect(clippy::let_underscore_must_use, reason = "No use for this Copy type")]
     let _: BedrockStatus = val.bedrock_status.into();
 
-    let _ = MantleMsgId(val.bedrock_parent_id.data);
-
     unsafe {
         free_ffi_transaction_vec(ffi_tx_ffi_vec);
     };
@@ -165,8 +158,6 @@ pub unsafe extern "C" fn free_ffi_block_opt(val: FfiBlockOpt) {
 
         #[expect(clippy::let_underscore_must_use, reason = "No use for this Copy type")]
         let _: BedrockStatus = value.bedrock_status.into();
-
-        let _ = MantleMsgId(value.bedrock_parent_id.data);
 
         unsafe {
             free_ffi_transaction_vec(ffi_tx_ffi_vec);

--- a/lez/indexer/ffi/src/api/types/mod.rs
+++ b/lez/indexer/ffi/src/api/types/mod.rs
@@ -1,4 +1,4 @@
-use indexer_service_protocol::{AccountId, HashType, MantleMsgId, ProgramId, PublicKey, Signature};
+use indexer_service_protocol::{AccountId, HashType, ProgramId, PublicKey, Signature};
 
 pub mod account;
 pub mod block;
@@ -68,7 +68,6 @@ impl From<FfiU128> for u128 {
 }
 
 pub type FfiHashType = FfiBytes32;
-pub type FfiMsgId = FfiBytes32;
 pub type FfiBlockId = u64;
 pub type FfiTimestamp = u64;
 pub type FfiSignature = FfiBytes64;
@@ -78,12 +77,6 @@ pub type FfiPublicKey = FfiBytes32;
 
 impl From<HashType> for FfiHashType {
     fn from(value: HashType) -> Self {
-        Self { data: value.0 }
-    }
-}
-
-impl From<MantleMsgId> for FfiMsgId {
-    fn from(value: MantleMsgId) -> Self {
         Self { data: value.0 }
     }
 }

--- a/lez/indexer/service/protocol/src/convert.rs
+++ b/lez/indexer/service/protocol/src/convert.rs
@@ -4,8 +4,8 @@ use lee_core::account::Nonce;
 
 use crate::{
     Account, AccountId, BedrockStatus, Block, BlockBody, BlockHeader, Ciphertext, Commitment,
-    CommitmentSetDigest, Data, EncryptedAccountData, EphemeralPublicKey, HashType, MantleMsgId,
-    Nullifier, PrivacyPreservingMessage, PrivacyPreservingTransaction, ProgramDeploymentMessage,
+    CommitmentSetDigest, Data, EncryptedAccountData, EphemeralPublicKey, HashType, Nullifier,
+    PrivacyPreservingMessage, PrivacyPreservingTransaction, ProgramDeploymentMessage,
     ProgramDeploymentTransaction, ProgramId, Proof, PublicKey, PublicMessage, PublicTransaction,
     Signature, Transaction, ValidityWindow, WitnessSet,
 };
@@ -630,14 +630,12 @@ impl From<common::block::Block> for Block {
             header,
             body,
             bedrock_status,
-            bedrock_parent_id,
         } = value;
 
         Self {
             header: header.into(),
             body: body.into(),
             bedrock_status: bedrock_status.into(),
-            bedrock_parent_id: MantleMsgId(bedrock_parent_id),
         }
     }
 }
@@ -650,14 +648,12 @@ impl TryFrom<Block> for common::block::Block {
             header,
             body,
             bedrock_status,
-            bedrock_parent_id,
         } = value;
 
         Ok(Self {
             header: header.try_into()?,
             body: body.try_into()?,
             bedrock_status: bedrock_status.into(),
-            bedrock_parent_id: bedrock_parent_id.0,
         })
     }
 }

--- a/lez/indexer/service/protocol/src/lib.rs
+++ b/lez/indexer/service/protocol/src/lib.rs
@@ -145,7 +145,6 @@ pub struct Block {
     pub header: BlockHeader,
     pub body: BlockBody,
     pub bedrock_status: BedrockStatus,
-    pub bedrock_parent_id: MantleMsgId,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
@@ -357,13 +356,6 @@ impl FromStr for HashType {
         Ok(Self(bytes))
     }
 }
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
-pub struct MantleMsgId(
-    #[serde(with = "base64::arr")]
-    #[schemars(with = "String", description = "base64-encoded Bedrock message id")]
-    pub [u8; 32],
-);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum BedrockStatus {

--- a/lez/indexer/service/src/mock_service.rs
+++ b/lez/indexer/service/src/mock_service.rs
@@ -10,10 +10,10 @@ use std::{collections::HashMap, sync::Arc, time::Duration};
 
 use indexer_service_protocol::{
     Account, AccountId, BedrockStatus, Block, BlockBody, BlockHeader, BlockId, Commitment,
-    CommitmentSetDigest, Data, EncryptedAccountData, HashType, MantleMsgId,
-    PrivacyPreservingMessage, PrivacyPreservingTransaction, ProgramDeploymentMessage,
-    ProgramDeploymentTransaction, ProgramId, PublicMessage, PublicTransaction, Signature,
-    Transaction, ValidityWindow, WitnessSet,
+    CommitmentSetDigest, Data, EncryptedAccountData, HashType, PrivacyPreservingMessage,
+    PrivacyPreservingTransaction, ProgramDeploymentMessage, ProgramDeploymentTransaction,
+    ProgramId, PublicMessage, PublicTransaction, Signature, Transaction, ValidityWindow,
+    WitnessSet,
 };
 use jsonrpsee::{
     core::{SubscriptionResult, async_trait},
@@ -432,7 +432,6 @@ fn build_mock_block(
             transactions: block_transactions,
         },
         bedrock_status,
-        bedrock_parent_id: MantleMsgId([0; 32]),
     }
 }
 

--- a/lez/sequencer/core/src/block_store.rs
+++ b/lez/sequencer/core/src/block_store.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, path::Path, sync::Arc};
 use anyhow::{Context as _, Result};
 use common::{
     HashType,
-    block::{Block, BlockMeta, MantleMsgId},
+    block::{Block, BlockMeta},
     transaction::LeeTransaction,
 };
 use lee::V03State;
@@ -56,16 +56,10 @@ impl SequencerStore {
     pub fn create_db_with_genesis(
         location: &Path,
         genesis_block: &Block,
-        genesis_msg_id: MantleMsgId,
         genesis_state: &V03State,
         signing_key: lee::PrivateKey,
     ) -> DbResult<Self> {
-        let dbio = Arc::new(RocksDBIO::create(
-            location,
-            genesis_block,
-            genesis_msg_id,
-            genesis_state,
-        )?);
+        let dbio = Arc::new(RocksDBIO::create(location, genesis_block, genesis_state)?);
         let genesis_id = dbio.get_meta_first_block_in_db()?;
         let tx_hash_to_block_map = block_to_transactions_map(genesis_block);
 
@@ -134,14 +128,9 @@ impl SequencerStore {
         self.dbio.get_all_blocks()
     }
 
-    pub(crate) fn update(
-        &mut self,
-        block: &Block,
-        msg_id: MantleMsgId,
-        state: &V03State,
-    ) -> DbResult<()> {
+    pub(crate) fn update(&mut self, block: &Block, state: &V03State) -> DbResult<()> {
         let new_transactions_map = block_to_transactions_map(block);
-        self.dbio.atomic_update(block, msg_id, state)?;
+        self.dbio.atomic_update(block, state)?;
         self.tx_hash_to_block_map.extend(new_transactions_map);
         Ok(())
     }
@@ -225,7 +214,6 @@ mod tests {
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
-            [0; 32],
             &testnet_initial_state::initial_state(),
             signing_key,
         )
@@ -239,7 +227,7 @@ mod tests {
         assert_eq!(None, retrieved_tx);
         // Add the block with the transaction
         let dummy_state = V03State::new_with_genesis_accounts(&[], vec![], 0);
-        node_store.update(&block, [1; 32], &dummy_state).unwrap();
+        node_store.update(&block, &dummy_state).unwrap();
         // Try again
         let retrieved_tx = node_store.get_transaction_by_hash(tx.hash());
         assert_eq!(Some(tx), retrieved_tx);
@@ -265,7 +253,6 @@ mod tests {
         let node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
-            [0; 32],
             &testnet_initial_state::initial_state(),
             signing_key,
         )
@@ -274,7 +261,6 @@ mod tests {
         // Verify that initially the latest block hash equals genesis hash
         let latest_meta = node_store.latest_block_meta().unwrap();
         assert_eq!(latest_meta.hash, genesis_hash);
-        assert_eq!(latest_meta.msg_id, [0; 32]);
     }
 
     #[test]
@@ -295,7 +281,6 @@ mod tests {
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
-            [0; 32],
             &testnet_initial_state::initial_state(),
             signing_key,
         )
@@ -305,17 +290,13 @@ mod tests {
         let tx = common::test_utils::produce_dummy_empty_transaction();
         let block = common::test_utils::produce_dummy_block(1, None, vec![tx]);
         let block_hash = block.header.hash;
-        let block_msg_id = [1; 32];
 
         let dummy_state = V03State::new_with_genesis_accounts(&[], vec![], 0);
-        node_store
-            .update(&block, block_msg_id, &dummy_state)
-            .unwrap();
+        node_store.update(&block, &dummy_state).unwrap();
 
-        // Verify that the latest block meta now equals the new block's hash and msg_id
+        // Verify that the latest block meta now equals the new block's hash
         let latest_meta = node_store.latest_block_meta().unwrap();
         assert_eq!(latest_meta.hash, block_hash);
-        assert_eq!(latest_meta.msg_id, block_msg_id);
     }
 
     #[test]
@@ -336,7 +317,6 @@ mod tests {
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
-            [0; 32],
             &testnet_initial_state::initial_state(),
             signing_key,
         )
@@ -348,7 +328,7 @@ mod tests {
         let block_id = block.header.block_id;
 
         let dummy_state = V03State::new_with_genesis_accounts(&[], vec![], 0);
-        node_store.update(&block, [1; 32], &dummy_state).unwrap();
+        node_store.update(&block, &dummy_state).unwrap();
 
         // Verify initial status is Pending
         let retrieved_block = node_store.get_block_at_id(block_id).unwrap().unwrap();
@@ -389,7 +369,6 @@ mod tests {
             let mut node_store = SequencerStore::create_db_with_genesis(
                 path,
                 &genesis_block,
-                [0; 32],
                 &testnet_initial_state::initial_state(),
                 signing_key.clone(),
             )
@@ -398,11 +377,7 @@ mod tests {
             // Add a new block
             let block = common::test_utils::produce_dummy_block(1, None, vec![tx.clone()]);
             node_store
-                .update(
-                    &block,
-                    [1; 32],
-                    &V03State::new_with_genesis_accounts(&[], vec![], 0),
-                )
+                .update(&block, &V03State::new_with_genesis_accounts(&[], vec![], 0))
                 .unwrap();
         }
 

--- a/lez/sequencer/core/src/block_store.rs
+++ b/lez/sequencer/core/src/block_store.rs
@@ -209,7 +209,7 @@ mod tests {
             transactions: vec![],
         };
 
-        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key);
         // Start an empty node store
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
@@ -247,7 +247,7 @@ mod tests {
             transactions: vec![],
         };
 
-        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key);
         let genesis_hash = genesis_block.header.hash;
 
         let node_store = SequencerStore::create_db_with_genesis(
@@ -277,7 +277,7 @@ mod tests {
             transactions: vec![],
         };
 
-        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key);
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
@@ -313,7 +313,7 @@ mod tests {
             transactions: vec![],
         };
 
-        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key);
         let mut node_store = SequencerStore::create_db_with_genesis(
             path,
             &genesis_block,
@@ -362,7 +362,7 @@ mod tests {
             transactions: vec![],
         };
 
-        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_block_hashable_data.into_pending_block(&signing_key);
         let tx = common::test_utils::produce_dummy_empty_transaction();
         {
             // Create a scope to drop the first store after creating the db

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -96,7 +96,6 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
                 db_path.display()
             );
 
-            let genesis_parent_msg_id = [0; 32];
             let (genesis_state, genesis_txs) = build_genesis_state(&config);
 
             let hashable_data = HashableBlockData {
@@ -105,8 +104,7 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
                 prev_block_hash: HashType([0; 32]),
                 timestamp: 0,
             };
-            let genesis_block =
-                hashable_data.into_pending_block(&signing_key, genesis_parent_msg_id);
+            let genesis_block = hashable_data.into_pending_block(&signing_key);
 
             let store = SequencerStore::create_db_with_genesis(
                 &db_path,
@@ -414,12 +412,9 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
             timestamp: new_block_timestamp,
         };
 
-        // TODO: Remove bedrock_parent_id from Block — it is no longer needed now
-        // that zone-sdk manages the inscription parent chain internally.
-        let placeholder_parent_id = [0_u8; 32];
         let block = hashable_data
             .clone()
-            .into_pending_block(self.store.signing_key(), placeholder_parent_id);
+            .into_pending_block(self.store.signing_key());
 
         self.chain_height = new_block_height;
 
@@ -831,7 +826,7 @@ mod tests {
             prev_block_hash: HashType([0; 32]),
             timestamp: 0,
         };
-        let genesis_block = genesis_hashable_data.into_pending_block(&signing_key, [0; 32]);
+        let genesis_block = genesis_hashable_data.into_pending_block(&signing_key);
 
         SequencerStore::create_db_with_genesis(
             &config.home.join("rocksdb"),

--- a/lez/sequencer/core/src/lib.rs
+++ b/lez/sequencer/core/src/lib.rs
@@ -96,9 +96,6 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
                 db_path.display()
             );
 
-            // TODO: Remove msg_id from BlockMeta — it is no longer needed now that
-            // zone-sdk manages L1 settlement state via its own checkpoint.
-            let genesis_msg_id = [0; 32];
             let genesis_parent_msg_id = [0; 32];
             let (genesis_state, genesis_txs) = build_genesis_state(&config);
 
@@ -114,7 +111,6 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
             let store = SequencerStore::create_db_with_genesis(
                 &db_path,
                 &genesis_block,
-                genesis_msg_id,
                 &genesis_state,
                 signing_key,
             )
@@ -275,16 +271,12 @@ impl<BP: BlockPublisherTrait> SequencerCore<BP> {
             deposit_event_ids,
         } = block_with_meta;
 
-        // TODO: Remove msg_id from store.update — it is no longer needed now that
-        // zone-sdk manages L1 settlement state via its own checkpoint.
-        let placeholder_msg_id = [0_u8; 32];
-
         self.block_publisher
             .publish_block(&block)
             .await
             .context("Failed to publish block to Bedrock")?;
 
-        self.store.update(&block, placeholder_msg_id, &self.state)?;
+        self.store.update(&block, &self.state)?;
 
         let updated_deposits = self
             .store
@@ -841,11 +833,9 @@ mod tests {
         };
         let genesis_block = genesis_hashable_data.into_pending_block(&signing_key, [0; 32]);
 
-        let expected_msg_id = [7; 32];
         SequencerStore::create_db_with_genesis(
             &config.home.join("rocksdb"),
             &genesis_block,
-            expected_msg_id,
             &genesis_state,
             signing_key,
         )
@@ -853,10 +843,8 @@ mod tests {
 
         let (sequencer, _mempool_handle) =
             SequencerCoreWithMockClients::start_from_config(config).await;
-        let latest_meta = sequencer.store.latest_block_meta().unwrap();
-
-        assert_eq!(latest_meta.msg_id, expected_msg_id);
         assert_eq!(sequencer.chain_height, 1);
+        assert!(sequencer.store.latest_block_meta().is_ok());
     }
 
     #[should_panic(expected = "Failed to open database")]

--- a/lez/storage/src/sequencer/mod.rs
+++ b/lez/storage/src/sequencer/mod.rs
@@ -2,7 +2,7 @@ use std::{path::Path, sync::Arc};
 
 use common::{
     HashType,
-    block::{BedrockStatus, Block, BlockMeta, MantleMsgId},
+    block::{BedrockStatus, Block, BlockMeta},
 };
 use lee::V03State;
 use rocksdb::{
@@ -54,12 +54,7 @@ impl RocksDBIO {
         Self::open_inner(path, &db_opts)
     }
 
-    pub fn create(
-        path: &Path,
-        genesis_block: &Block,
-        genesis_msg_id: MantleMsgId,
-        genesis_state: &V03State,
-    ) -> DbResult<Self> {
+    pub fn create(path: &Path, genesis_block: &Block, genesis_state: &V03State) -> DbResult<Self> {
         let mut db_opts = Options::default();
         db_opts.create_missing_column_families(true);
         db_opts.create_if_missing(true);
@@ -69,14 +64,13 @@ impl RocksDBIO {
         if !is_start_set {
             let block_id = genesis_block.header.block_id;
             // TODO: Shouldn't this be atomic (batched)?
-            dbio.put_meta_first_block_in_db(genesis_block, genesis_msg_id)?;
+            dbio.put_meta_first_block_in_db(genesis_block)?;
             dbio.put_meta_is_first_block_set()?;
             dbio.put_meta_last_block_in_db(block_id)?;
             dbio.put_meta_last_finalized_block_id(None)?;
             dbio.put_meta_latest_block_meta(&BlockMeta {
                 id: genesis_block.header.block_id,
                 hash: genesis_block.header.hash,
-                msg_id: genesis_msg_id,
             })?;
             dbio.put_lee_state_in_db(genesis_state)?;
         }
@@ -168,7 +162,7 @@ impl RocksDBIO {
         self.put_batch(&LEEStateCellRef(state), (), batch)
     }
 
-    pub fn put_meta_first_block_in_db(&self, block: &Block, msg_id: MantleMsgId) -> DbResult<()> {
+    pub fn put_meta_first_block_in_db(&self, block: &Block) -> DbResult<()> {
         let cf_meta = self.meta_column();
         self.db
             .put_cf(
@@ -189,7 +183,7 @@ impl RocksDBIO {
             .map_err(|rerr| DbError::rocksdb_cast_message(rerr, None))?;
 
         let mut batch = WriteBatch::default();
-        self.put_block(block, msg_id, true, &mut batch)?;
+        self.put_block(block, true, &mut batch)?;
         self.db.write(batch).map_err(|rerr| {
             DbError::rocksdb_cast_message(
                 rerr,
@@ -312,13 +306,7 @@ impl RocksDBIO {
         Ok(removed)
     }
 
-    pub fn put_block(
-        &self,
-        block: &Block,
-        msg_id: MantleMsgId,
-        first: bool,
-        batch: &mut WriteBatch,
-    ) -> DbResult<()> {
+    pub fn put_block(&self, block: &Block, first: bool, batch: &mut WriteBatch) -> DbResult<()> {
         let cf_block = self.block_column();
 
         if !first {
@@ -330,7 +318,6 @@ impl RocksDBIO {
                     &BlockMeta {
                         id: block.header.block_id,
                         hash: block.header.hash,
-                        msg_id,
                     },
                     batch,
                 )?;
@@ -452,15 +439,10 @@ impl RocksDBIO {
             })
     }
 
-    pub fn atomic_update(
-        &self,
-        block: &Block,
-        msg_id: MantleMsgId,
-        state: &V03State,
-    ) -> DbResult<()> {
+    pub fn atomic_update(&self, block: &Block, state: &V03State) -> DbResult<()> {
         let block_id = block.header.block_id;
         let mut batch = WriteBatch::default();
-        self.put_block(block, msg_id, false, &mut batch)?;
+        self.put_block(block, false, &mut batch)?;
         self.put_lee_state_in_db_batch(state, &mut batch)?;
         self.db.write(batch).map_err(|rerr| {
             DbError::rocksdb_cast_message(


### PR DESCRIPTION
## 🎯 Purpose


- BREAKING CHANGE: `msg_id` field of `BlockMeta` is now declared redundant, as also hinted by several TODO comments indicating its removal.

https://github.com/logos-blockchain/logos-execution-zone/blob/feb6cb7f92d9926411b1aa00486fe198bd05bf13/lez/common/src/block.rs#L11-L17

- BREAKING CHANGE: `bedrock_parent_id` field of `Block` is now declared redundant, as also hinted by a TODO comment indicating its removal.

https://github.com/logos-blockchain/logos-execution-zone/blob/feb6cb7f92d9926411b1aa00486fe198bd05bf13/lez/common/src/block.rs#L54-L59

This PR removes the said fields, along with numerous places where it is used & taken as a parameter. Tests and inline comments are edited accordingly.

> [!CAUTION]
>
> This changes the parsing logic of the data within RocksDB; existing data will fail to Borsch parse due to the missing field. No migration scripts were required, as there will instead be a clean-slate restart with the later version.

## ⚙️ Approach

- [x] Remove `msg_id` from `BlockMeta` in `common`, and remove all cascaded usages of it. 
- [x] Remove `bedrock_parent_id` from `Block` in `common`, and remove all cascaded usages of it. 
- [x] Remove `MantleMsgId`, `FfiMsgId` and `MantleMsgId`
- [x] Remove related TODO comments
- [x] Remove `assert` checks in tests that were using the removed fields, edit inline comments accordingly.
- [x] Regenerate the FFI header with `cargo build -p indexer_ffi `

## 🧪 How to Test

```sh
# test affected crates, including mock feature
cargo test -p sequencer_core -p storage -p common --all-features

# ensure all pass with the broadest check
cargo check --workspace --all-targets --all-features

# see for yourself that these words do not appear anymore
grep -rn "bedrock_parent_id\|MantleMsgId\|FfiMsgId" lez/ lee/ 
```

> [!NOTE]
> The `--all-targets` and `--all-features` is required to account for `test` target with `mock` feature (of Sequencer).

## 🔗 Dependencies

None.

## 🔜 Future Work

None here. Related services should take care of the breaking change updates.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
