### PR TITLE
fix(indexer): bypass system account guards

### DIFF
--- a/integration_tests/tests/bridge.rs
+++ b/integration_tests/tests/bridge.rs
@@ -4,7 +4,7 @@
     reason = "We don't care about these in tests"
 )]
 
-use std::{ops::Deref, time::Duration};
+use std::{ops::Deref as _, time::Duration};
 
 use anyhow::Context as _;
 use borsh::BorshSerialize;

--- a/integration_tests/tests/bridge.rs
+++ b/integration_tests/tests/bridge.rs
@@ -459,7 +459,8 @@ async fn bedrock_deposit_mints_to_vault_then_claim_succeeds() -> anyhow::Result<
     let bridge_account_id = lee::system_bridge_account_id();
     for account_id in [recipient_id, recipient_vault_id, bridge_account_id] {
         let indexer_account = indexer_service_rpc::RpcClient::get_account(
-            // `deref` is needed for correct trait resolution of the async `get_account` method on `RpcClient`
+            // `deref` is needed for correct trait resolution
+            // of the async `get_account` method on `RpcClient`
             ctx.indexer_client().deref(),
             account_id.into(),
         )

--- a/integration_tests/tests/bridge.rs
+++ b/integration_tests/tests/bridge.rs
@@ -4,12 +4,14 @@
     reason = "We don't care about these in tests"
 )]
 
-use std::time::Duration;
+use std::{ops::Deref, time::Duration};
 
 use anyhow::Context as _;
 use borsh::BorshSerialize;
 use common::transaction::LeeTransaction;
-use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext};
+use integration_tests::{
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, wait_for_indexer_to_catch_up,
+};
 use lee::{
     AccountId, execute_and_prove, privacy_preserving_transaction, program::Program,
     public_transaction,
@@ -449,6 +451,26 @@ async fn bedrock_deposit_mints_to_vault_then_claim_succeeds() -> anyhow::Result<
         recipient_balance_before + 1,
         "Recipient balance should increase by claimed amount"
     );
+
+    // The indexer must replay the deposit and claim blocks and reach the same
+    // state as the sequencer — including the bridge system account the deposit
+    // modifies, which is the case the hot fix unblocks.
+    wait_for_indexer_to_catch_up(&ctx).await?;
+    let bridge_account_id = lee::system_bridge_account_id();
+    for account_id in [recipient_id, recipient_vault_id, bridge_account_id] {
+        let indexer_account = indexer_service_rpc::RpcClient::get_account(
+            // `deref` is needed for correct trait resolution of the async `get_account` method on `RpcClient`
+            ctx.indexer_client().deref(),
+            account_id.into(),
+        )
+        .await?;
+        let sequencer_account = ctx.sequencer_client().get_account(account_id).await?;
+        assert_eq!(
+            indexer_account,
+            sequencer_account.into(),
+            "Indexer and sequencer diverged for account {account_id} after deposit"
+        );
+    }
 
     Ok(())
 }

--- a/lez/common/src/transaction.rs
+++ b/lez/common/src/transaction.rs
@@ -137,7 +137,7 @@ impl LeeTransaction {
     /// tag that lets the sequencer bypass the guard is not carried in the block,
     /// so the indexer cannot yet distinguish deposit txs from user txs.
     ///
-    /// REMOVE ME when the indexer can authenticate deposit transactions
+    /// REMOVE ME when the indexer can authenticate deposit transactions.
     pub fn execute_unchecked_on_state(
         self,
         state: &mut V03State,

--- a/lez/common/src/transaction.rs
+++ b/lez/common/src/transaction.rs
@@ -94,7 +94,7 @@ impl LeeTransaction {
 
     /// Computes the validated state diff without enforcing the system-account
     /// restriction. Shared by [`Self::validate_on_state`] and
-    /// [`Self::execute_unchecked_on_state`].
+    /// [`Self::execute_without_system_accounts_check_on_state`].
     fn compute_state_diff(
         &self,
         state: &V03State,
@@ -138,7 +138,7 @@ impl LeeTransaction {
     /// so the indexer cannot yet distinguish deposit txs from user txs.
     ///
     /// REMOVE ME when the indexer can authenticate deposit transactions.
-    pub fn execute_unchecked_on_state(
+    pub fn execute_without_system_accounts_check_on_state(
         self,
         state: &mut V03State,
         block_id: BlockId,

--- a/lez/common/src/transaction.rs
+++ b/lez/common/src/transaction.rs
@@ -78,18 +78,9 @@ impl LeeTransaction {
         block_id: BlockId,
         timestamp: Timestamp,
     ) -> Result<ValidatedStateDiff, lee::error::LeeError> {
-        let diff = match self {
-            Self::Public(tx) => {
-                ValidatedStateDiff::from_public_transaction(tx, state, block_id, timestamp)
-            }
-            Self::PrivacyPreserving(tx) => ValidatedStateDiff::from_privacy_preserving_transaction(
-                tx, state, block_id, timestamp,
-            ),
-            Self::ProgramDeployment(tx) => {
-                ValidatedStateDiff::from_program_deployment_transaction(tx, state)
-            }
-        }?;
+        let diff = self.compute_state_diff(state, block_id, timestamp)?;
 
+        // system accounts guard
         let system_accounts = lee::CLOCK_PROGRAM_ACCOUNT_IDS.iter().copied().chain([
             lee::system_faucet_account_id(),
             lee::system_bridge_account_id(),
@@ -99,6 +90,28 @@ impl LeeTransaction {
         }
 
         Ok(diff)
+    }
+
+    /// Computes the validated state diff without enforcing the system-account
+    /// restriction. Shared by [`Self::validate_on_state`] and
+    /// [`Self::execute_unchecked_on_state`].
+    fn compute_state_diff(
+        &self,
+        state: &V03State,
+        block_id: BlockId,
+        timestamp: Timestamp,
+    ) -> Result<ValidatedStateDiff, lee::error::LeeError> {
+        match self {
+            Self::Public(tx) => {
+                ValidatedStateDiff::from_public_transaction(tx, state, block_id, timestamp)
+            }
+            Self::PrivacyPreserving(tx) => ValidatedStateDiff::from_privacy_preserving_transaction(
+                tx, state, block_id, timestamp,
+            ),
+            Self::ProgramDeployment(tx) => {
+                ValidatedStateDiff::from_program_deployment_transaction(tx, state)
+            }
+        }
     }
 
     /// Validates the transaction against the current state, rejects modifications to clock
@@ -111,6 +124,28 @@ impl LeeTransaction {
     ) -> Result<Self, lee::error::LeeError> {
         let diff = self
             .validate_on_state(state, block_id, timestamp)
+            .inspect_err(|err| warn!("Error at transition {err:#?}"))?;
+        state.apply_state_diff(diff);
+        Ok(self)
+    }
+
+    /// Similar to [`Self::execute_check_on_state`], but skips the system-account guard.
+    ///
+    /// FIXME: HOT FIX (testnet v0.2): the indexer replays blocks the sequencer already
+    /// accepted, including sequencer-generated deposit transactions that
+    /// legitimately modify the bridge account. The `TransactionOrigin::Sequencer`
+    /// tag that lets the sequencer bypass the guard is not carried in the block,
+    /// so the indexer cannot yet distinguish deposit txs from user txs.
+    ///
+    /// REMOVE ME when the indexer can authenticate deposit transactions
+    pub fn execute_unchecked_on_state(
+        self,
+        state: &mut V03State,
+        block_id: BlockId,
+        timestamp: Timestamp,
+    ) -> Result<Self, lee::error::LeeError> {
+        let diff = self
+            .compute_state_diff(state, block_id, timestamp)
             .inspect_err(|err| warn!("Error at transition {err:#?}"))?;
         state.apply_state_diff(diff);
         Ok(self)

--- a/lez/indexer/core/src/block_store.rs
+++ b/lez/indexer/core/src/block_store.rs
@@ -171,7 +171,10 @@ impl IndexerStore {
                     transaction
                         .clone()
                         .transaction_stateless_check()?
-                        .execute_check_on_state(
+                        // FIXME: HOT FIX (testnet v0.2): does not check for system account updates due to
+                        // sequencer-generated deposit tx'es;
+                        // CHANGE ME back to `execute_check_on_state` when the indexer can authenticate deposit transactions
+                        .execute_unchecked_on_state(
                             &mut state_guard,
                             block.header.block_id,
                             block.header.timestamp,

--- a/lez/indexer/core/src/block_store.rs
+++ b/lez/indexer/core/src/block_store.rs
@@ -174,7 +174,7 @@ impl IndexerStore {
                         // FIXME: HOT FIX (testnet v0.2): does not check for system account updates due to
                         // sequencer-generated deposit tx'es;
                         // CHANGE ME back to `execute_check_on_state` when the indexer can authenticate deposit transactions
-                        .execute_unchecked_on_state(
+                        .execute_without_system_accounts_check_on_state(
                             &mut state_guard,
                             block.header.block_id,
                             block.header.timestamp,

--- a/lez/storage/src/indexer/mod.rs
+++ b/lez/storage/src/indexer/mod.rs
@@ -211,7 +211,7 @@ impl RocksDBIO {
                         // FIXME: HOT FIX (testnet v0.2): does not check for system account updates due to
                         // sequencer-generated deposit tx'es;
                         // CHANGE ME back to `execute_check_on_state` when the indexer can authenticate deposit transactions
-                        .execute_unchecked_on_state(
+                        .execute_without_system_accounts_check_on_state(
                             &mut breakpoint,
                             block.header.block_id,
                             block.header.timestamp,

--- a/lez/storage/src/indexer/mod.rs
+++ b/lez/storage/src/indexer/mod.rs
@@ -208,7 +208,10 @@ impl RocksDBIO {
                                 "transaction pre check failed with err {err:?}"
                             ))
                         })?
-                        .execute_check_on_state(
+                        // FIXME: HOT FIX (testnet v0.2): does not check for system account updates due to
+                        // sequencer-generated deposit tx'es;
+                        // CHANGE ME back to `execute_check_on_state` when the indexer can authenticate deposit transactions
+                        .execute_unchecked_on_state(
                             &mut breakpoint,
                             block.header.block_id,
                             block.header.timestamp,


### PR DESCRIPTION
## 🎯 Purpose

The new deposit transactions are sequencer-originated, NOT user-originated; and they upgrade the system accounts. Such transactions are prevented by the system account guard of the `indexer` within state validations; but not on the sequencer side. This causes a state-divergence after a deposit happens.

While a proper fix & handling is required, this PR creates a hot-fix for the sake of allowing testnet v0.2 to work with the indexer & sequencer.

## ⚙️ Approach

- [x] Change two `execute_check_on_state` calls to the new `execute_without_system_accounts_check_on_state` within `indexer`
- [x] Add `execute_without_system_accounts_check_on_state`, akin to `execute_check_on_state` but does not check system account differences
- [x] Add `compute_state_diff` (shared between `execute_*_on_state` functions to compute the state difference)
- [x] Add indexer vs sequencer system account state comparison at the end of `bedrock_deposit_mints_to_vault_then_claim_succeeds` integration test

## 🧪 How to Test

The command below runs the happy-path end-to-end bridge test: 

```sh
RUST_LOG=info RISC0_DEV_MODE=1 cargo test -p integration_tests --test bridge -- bedrock_deposit_mints_to_vault_then_claim_succeeds --exact --nocapture --include-ignored
```

The test itself as it is written in this branch should fail in target `main` branch, because indexer will not allow the deposit transactions. Seeing that the test fails on `main` but passes here demonstrates that indexer hot-fix is correct. The failure looks like a bunch of error logs followed by the final assertion panic:

```sh
assertion `left == right` failed: Indexer and sequencer diverged for account 891294mzQ2pn5JrKtFc3NuDPUYQgbjqB4333fAcrCx2x after deposit
  left: Account { program_owner: ProgramId([2172491596, 648287714, 3443481193, 1757114575, 2729968860, 2157376487, 835305942, 2223466012]), balance: 10000, data: Data([]), nonce: 1 }
 right: Account { program_owner: ProgramId([2172491596, 648287714, 3443481193, 1757114575, 2729968860, 2157376487, 835305942, 2223466012]), balance: 10001, data: Data([]), nonce: 2 }
```

There are no error logs in this branch's version, nor a failure.

## 🔗 Dependencies

None

## 🔜 Future Work

A proper fix is required, in place of this hot-fix. Relevant TODO comments are placed to remove the hot-fix related code.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
