### PR TITLE
bump: pyo3 to 0.29

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,7 +2203,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2707,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4089,15 +4089,6 @@ dependencies = [
  "unicode-width",
  "unit-prefix",
  "web-time",
-]
-
-[[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
 ]
 
 [[package]]
@@ -6375,15 +6366,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mempool"
 version = "0.1.0"
 dependencies = [
@@ -7718,37 +7700,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -7756,9 +7733,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -7768,13 +7745,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -8765,7 +8741,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9783,7 +9759,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10674,12 +10650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
 name = "unit-prefix"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11207,7 +11177,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ actix-web = { version = "4.13.0", default-features = false, features = [
 ] }
 clap = { version = "4.5.42", features = ["derive", "env"] }
 reqwest = { version = "0.12", features = ["json", "rustls-tls", "stream"] }
-pyo3 = { version = "0.24", features = ["auto-initialize"] }
+pyo3 = { version = "0.29", features = ["auto-initialize"] }
 zeroize = "1"
 criterion = { version = "0.8", features = ["html_reports"] }
 

--- a/lez/keycard_wallet/src/lib.rs
+++ b/lez/keycard_wallet/src/lib.rs
@@ -124,7 +124,7 @@ impl KeycardWallet {
     }
 
     pub fn get_public_key_for_path_with_connect(pin: &str, path: &str) -> PyResult<PublicKey> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             python_path::add_python_path(py)?;
             let wallet = Self::new(py)?;
             wallet.connect(py, pin)?;
@@ -191,7 +191,7 @@ impl KeycardWallet {
         path: &str,
         message: &[u8; 32],
     ) -> PyResult<(Signature, PublicKey)> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             python_path::add_python_path(py)?;
             let wallet = Self::new(py)?;
             wallet.connect(py, pin)?;
@@ -258,7 +258,7 @@ impl KeycardWallet {
         pin: &str,
         path: &str,
     ) -> PyResult<PrivateKeyPair> {
-        Python::with_gil(|py| {
+        Python::attach(|py| {
             python_path::add_python_path(py)?;
             let wallet = Self::new(py)?;
             wallet.connect(py, pin)?;

--- a/lez/keycard_wallet/src/python_path.rs
+++ b/lez/keycard_wallet/src/python_path.rs
@@ -48,7 +48,7 @@ pub fn add_python_path(py: Python<'_>) -> PyResult<()> {
 
     let sys = PyModule::import(py, "sys")?;
     let binding = sys.getattr("path")?;
-    let sys_path = binding.downcast::<PyList>()?;
+    let sys_path = binding.cast::<PyList>()?;
 
     for path in &paths_to_add {
         let path_str = path.to_str().expect("Invalid path");

--- a/lez/wallet/src/account_manager.rs
+++ b/lez/wallet/src/account_manager.rs
@@ -412,7 +412,7 @@ impl AccountManager {
             .collect();
 
         if let Some(pin) = self.pin.clone() {
-            pyo3::Python::with_gil(|py| -> pyo3::PyResult<()> {
+            pyo3::Python::attach(|py| -> pyo3::PyResult<()> {
                 python_path::add_python_path(py)?;
                 let wallet = KeycardWallet::new(py)?;
                 wallet.connect(py, &pin)?;

--- a/lez/wallet/src/cli/keycard.rs
+++ b/lez/wallet/src/cli/keycard.rs
@@ -39,7 +39,7 @@ impl WalletSubcommand for KeycardSubcommand {
     ) -> Result<SubcommandReturnValue> {
         match self {
             Self::Available => {
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     python_path::add_python_path(py)
                         .expect("`wallet::keycard::available`: unable to setup python path");
 
@@ -61,7 +61,7 @@ impl WalletSubcommand for KeycardSubcommand {
             Self::Connect => {
                 let pin = read_pin()?;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     python_path::add_python_path(py)
                         .expect("`wallet::keycard::connect`: unable to setup python path");
 
@@ -81,7 +81,7 @@ impl WalletSubcommand for KeycardSubcommand {
             Self::Disconnect => {
                 let pin = read_pin()?;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     python_path::add_python_path(py)
                         .expect("`wallet::keycard::disconnect`: unable to setup python path");
 
@@ -105,7 +105,7 @@ impl WalletSubcommand for KeycardSubcommand {
             Self::Init => {
                 let pin = read_pin()?;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     python_path::add_python_path(py)
                         .expect("`wallet::keycard::init`: unable to setup python path");
 
@@ -128,7 +128,7 @@ impl WalletSubcommand for KeycardSubcommand {
                 let pin = read_pin()?;
                 let mnemonic = read_mnemonic()?;
 
-                Python::with_gil(|py| {
+                Python::attach(|py| {
                     python_path::add_python_path(py)
                         .expect("`wallet::keycard::load`: unable to setup python path");
 


### PR DESCRIPTION
## 🎯 Purpose

`cargo deny check` currently fails on main due to a pyo3 dependency. based on https://pyo3.rs/v0.29.0/migration this bumps the version to 0.29 and appropriately updates

- `with_gil` to `attach` 
- `downcast` to `cast`

## ⚙️ Approach

Bump the toml file and adapt the codebase appropriately.

- [x] Change .toml file pin
- [x] See which functions break
- [x] Change them appropriately

## 🧪 How to Test

Run `cargo deny check`

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
