### PR TITLE
fix(lee): Fix redundant `ELF.to_vec()` on `Program::*().id()` calls, and avoid redundant hash recomutations

### DIFF
--- a/lee/state_machine/src/program.rs
+++ b/lee/state_machine/src/program.rs
@@ -113,65 +113,97 @@ impl Program {
     #[must_use]
     pub fn authenticated_transfer_program() -> Self {
         Self {
-            id: AUTHENTICATED_TRANSFER_ID,
+            id: Self::authenticated_transfer_program_id(),
             elf: AUTHENTICATED_TRANSFER_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn authenticated_transfer_program_id() -> ProgramId {
+        AUTHENTICATED_TRANSFER_ID
     }
 
     #[must_use]
     pub fn token() -> Self {
         Self {
-            id: TOKEN_ID,
+            id: Self::token_id(),
             elf: TOKEN_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn token_id() -> ProgramId {
+        TOKEN_ID
     }
 
     #[must_use]
     pub fn amm() -> Self {
         Self {
-            id: AMM_ID,
+            id: Self::amm_id(),
             elf: AMM_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn amm_id() -> ProgramId {
+        AMM_ID
     }
 
     #[must_use]
     pub fn clock() -> Self {
         Self {
-            id: CLOCK_ID,
+            id: Self::clock_id(),
             elf: CLOCK_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn clock_id() -> ProgramId {
+        CLOCK_ID
     }
 
     #[must_use]
     pub fn ata() -> Self {
         Self {
-            id: ASSOCIATED_TOKEN_ACCOUNT_ID,
+            id: Self::ata_id(),
             elf: ASSOCIATED_TOKEN_ACCOUNT_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn ata_id() -> ProgramId {
+        ASSOCIATED_TOKEN_ACCOUNT_ID
     }
 
     #[must_use]
     pub fn vault() -> Self {
         Self {
-            id: VAULT_ID,
+            id: Self::vault_id(),
             elf: VAULT_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn vault_id() -> ProgramId {
+        VAULT_ID
     }
 
     #[must_use]
     pub fn faucet() -> Self {
         Self {
-            id: FAUCET_ID,
+            id: Self::faucet_id(),
             elf: FAUCET_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn faucet_id() -> ProgramId {
+        FAUCET_ID
     }
 
     #[must_use]
     pub fn bridge() -> Self {
         Self {
-            id: BRIDGE_ID,
+            id: Self::bridge_id(),
             elf: BRIDGE_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn bridge_id() -> ProgramId {
+        BRIDGE_ID
     }
 }
 
@@ -180,18 +212,25 @@ impl Program {
     #[must_use]
     pub fn pinata() -> Self {
         Self {
-            id: PINATA_ID,
+            id: Self::pinata_id(),
             elf: PINATA_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn pinata_id() -> ProgramId {
+        PINATA_ID
     }
 
     #[must_use]
     pub fn pinata_token() -> Self {
-        use crate::program_methods::{PINATA_TOKEN_ELF, PINATA_TOKEN_ID};
         Self {
-            id: PINATA_TOKEN_ID,
-            elf: PINATA_TOKEN_ELF.to_vec(),
+            id: Self::pinata_token_id(),
+            elf: crate::program_methods::PINATA_TOKEN_ELF.to_vec(),
         }
+    }
+    #[must_use]
+    pub const fn pinata_token_id() -> ProgramId {
+        crate::program_methods::PINATA_TOKEN_ID
     }
 }
 

--- a/lee/state_machine/src/program.rs
+++ b/lee/state_machine/src/program.rs
@@ -117,6 +117,7 @@ impl Program {
             elf: AUTHENTICATED_TRANSFER_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn authenticated_transfer_program_id() -> ProgramId {
         AUTHENTICATED_TRANSFER_ID
@@ -129,6 +130,7 @@ impl Program {
             elf: TOKEN_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn token_id() -> ProgramId {
         TOKEN_ID
@@ -141,6 +143,7 @@ impl Program {
             elf: AMM_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn amm_id() -> ProgramId {
         AMM_ID
@@ -153,6 +156,7 @@ impl Program {
             elf: CLOCK_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn clock_id() -> ProgramId {
         CLOCK_ID
@@ -165,6 +169,7 @@ impl Program {
             elf: ASSOCIATED_TOKEN_ACCOUNT_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn ata_id() -> ProgramId {
         ASSOCIATED_TOKEN_ACCOUNT_ID
@@ -177,6 +182,7 @@ impl Program {
             elf: VAULT_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn vault_id() -> ProgramId {
         VAULT_ID
@@ -189,6 +195,7 @@ impl Program {
             elf: FAUCET_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn faucet_id() -> ProgramId {
         FAUCET_ID
@@ -201,6 +208,7 @@ impl Program {
             elf: BRIDGE_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn bridge_id() -> ProgramId {
         BRIDGE_ID
@@ -216,6 +224,7 @@ impl Program {
             elf: PINATA_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn pinata_id() -> ProgramId {
         PINATA_ID
@@ -228,6 +237,7 @@ impl Program {
             elf: crate::program_methods::PINATA_TOKEN_ELF.to_vec(),
         }
     }
+
     #[must_use]
     pub const fn pinata_token_id() -> ProgramId {
         crate::program_methods::PINATA_TOKEN_ID

--- a/lee/state_machine/src/state.rs
+++ b/lee/state_machine/src/state.rs
@@ -1,4 +1,7 @@
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::{
+    collections::{BTreeSet, HashMap, HashSet},
+    sync::LazyLock,
+};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use clock_core::ClockAccountData;
@@ -24,6 +27,12 @@ use crate::{
 };
 
 pub const MAX_NUMBER_CHAINED_CALLS: usize = 10;
+
+static SYSTEM_FAUCET_ACCOUNT_ID: LazyLock<AccountId> =
+    LazyLock::new(|| faucet_core::compute_faucet_account_id(Program::faucet_id()));
+
+static SYSTEM_BRIDGE_ACCOUNT_ID: LazyLock<AccountId> =
+    LazyLock::new(|| bridge_core::compute_bridge_account_id(Program::bridge_id()));
 
 #[derive(Clone, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(test, derive(Debug, PartialEq, Eq))]
@@ -154,14 +163,13 @@ impl V03State {
     ) -> Self {
         let faucet_account_id = system_faucet_account_id();
         let bridge_account_id = system_bridge_account_id();
-        let authenticated_transfer_program = Program::authenticated_transfer_program();
         let mut public_state: HashMap<_, _> = initial_data
             .iter()
             .copied()
             .map(|(account_id, balance)| {
                 let account = Account {
                     balance,
-                    program_owner: authenticated_transfer_program.id(),
+                    program_owner: Program::authenticated_transfer_program_id(),
                     ..Account::default()
                 };
                 (account_id, account)
@@ -207,7 +215,7 @@ impl V03State {
             timestamp: genesis_timestamp,
         }
         .to_bytes();
-        let clock_program_id = Program::clock().id();
+        let clock_program_id = Program::clock_id();
         for account_id in CLOCK_PROGRAM_ACCOUNT_IDS {
             self.public_state.insert(
                 account_id,
@@ -350,7 +358,7 @@ impl V03State {
         self.public_state.insert(
             account_id,
             Account {
-                program_owner: Program::pinata().id(),
+                program_owner: Program::pinata_id(),
                 balance: 1_500_000,
                 // Difficulty: 3
                 data: vec![3; 33].try_into().expect("should fit"),
@@ -365,7 +373,7 @@ impl V03State {
         self.public_state.insert(
             account_id,
             Account {
-                program_owner: Program::pinata_token().id(),
+                program_owner: Program::pinata_token_id(),
                 // Difficulty: 3
                 data: vec![3; 33].try_into().expect("should fit"),
                 ..Account::default()
@@ -383,7 +391,7 @@ impl V03State {
 
 fn system_faucet_account() -> Account {
     Account {
-        program_owner: Program::authenticated_transfer_program().id(),
+        program_owner: Program::authenticated_transfer_program_id(),
         balance: u128::MAX,
         ..Account::default()
     }
@@ -391,19 +399,19 @@ fn system_faucet_account() -> Account {
 
 fn system_bridge_account() -> Account {
     Account {
-        program_owner: Program::authenticated_transfer_program().id(),
+        program_owner: Program::authenticated_transfer_program_id(),
         ..Account::default()
     }
 }
 
 #[must_use]
 pub fn system_faucet_account_id() -> AccountId {
-    faucet_core::compute_faucet_account_id(Program::faucet().id())
+    *SYSTEM_FAUCET_ACCOUNT_ID
 }
 
 #[must_use]
 pub fn system_bridge_account_id() -> AccountId {
-    bridge_core::compute_bridge_account_id(Program::bridge().id())
+    *SYSTEM_BRIDGE_ACCOUNT_ID
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## 🎯 Purpose

- Fixes #528 (see issue for details)

## ⚙️ Approach

`Program::*().id()` is optimized with alternative `id` only calls, `SYSTEM_FAUCET_ACCOUNT_ID` and `SYSTEM_BRIDGE_ACCOUNT_ID` now uses `LazyLock` to avoid hashing each time

- [x] Change `Program::*().id()` instances to `Program::*_id()` instead, skipping the redundant `ELF.to_vec()` on each call
- [x] Change `system_faucet_account_id` and `system_bridge_account_id` to use a static LazyLock'ed result instead of recomputing the same thing on each call

## 🧪 How to Test

```sh
# test specific package
cargo test -p lee --lib

# checks
cargo check --workspace --all-targets --all-features

# unit tests
RISC0_DEV_MODE=1 cargo nextest run --workspace --exclude integration_tests --no-fail-fast
```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
