### PR TITLE
docs: note python3-dev requirement and use rm -rf for circuits

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,21 +86,25 @@ lee_core = { git = "https://github.com/logos-blockchain/logos-execution-zone.git
 # Install dependencies
 ### Install build dependencies
 
+The wallet links against the system Python (via `pyo3`, used for keycard
+support), so the Python development package is required in addition to the
+usual build tools.
+
 - On Linux
 Ubuntu / Debian
 ```sh
-apt install build-essential clang libclang-dev libssl-dev pkg-config
+apt install build-essential clang libclang-dev libssl-dev pkg-config python3-dev
 ```
 
 - On Fedora
 ```sh
-sudo dnf install clang clang-devel openssl-devel pkgconf
+sudo dnf install clang clang-devel openssl-devel pkgconf python3-devel
 ```
 
 - On Mac
 ```sh
 xcode-select --install
-brew install pkg-config openssl
+brew install pkg-config openssl python
 ```
 
 ### Install Rust
@@ -147,7 +151,7 @@ The sequencer and logos blockchain node can be run locally:
  1. On one terminal go to the `logos-blockchain/logos-blockchain` repo and run a local logos blockchain node:
     - `git checkout master; git pull`
     - `cargo clean`
-    - `rm -r ~/.logos-blockchain-circuits`
+    - `rm -rf ~/.logos-blockchain-circuits`
     - `./scripts/setup-logos-blockchain-circuits.sh`
     - `cargo build --all-features`
     - `./target/debug/logos-blockchain-node --deployment nodes/node/standalone-deployment-config.yaml nodes/node/standalone-node-config.yaml`


### PR DESCRIPTION
## Summary

While building the wallet CLI (`cargo install --path lez/wallet`), the build failed at the final link step with `unable to find library -lpython3.14`. This is because the wallet depends on `pyo3` (directly and via `keycard_wallet`) with the `auto-initialize` feature, which links against the full system Python — requiring the Python development package. The README does not currently mention this.

This PR:
- Adds the Python dev package to each platform's build-dependency install command (`python3-dev` on Debian/Ubuntu, `python3-devel` on Fedora, `python` via brew on Mac) and notes why it's needed.
- Changes the circuits cleanup step from `rm -r ~/.logos-blockchain-circuits` to `rm -rf` so re-provisioning doesn't prompt or fail when the directory is absent.

## Verification

`grep -rni "python" README.md` previously returned nothing; the build dependency was undocumented. `cargo tree -p wallet -i pyo3` confirms `pyo3 v0.29.0` is a first-party dependency of both `wallet` and `keycard_wallet`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)