### PR TITLE
refactor(lee::signature)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,6 +157,7 @@ k256 = { version = "0.13.3", features = [
   "expose-field",
   "serde",
   "pem",
+  "schnorr",
 ] }
 ml-kem = { version = "0.3", features = ["hazmat"] }
 elliptic-curve = { version = "0.13.8", features = ["arithmetic"] }

--- a/lee/state_machine/src/signature/mod.rs
+++ b/lee/state_machine/src/signature/mod.rs
@@ -1,7 +1,7 @@
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
-use k256::ecdsa::signature::hazmat::PrehashVerifier;
+use k256::ecdsa::signature::hazmat::PrehashVerifier as _;
 pub use private_key::PrivateKey;
 pub use public_key::PublicKey;
 use rand::{RngCore as _, rngs::OsRng};

--- a/lee/state_machine/src/signature/mod.rs
+++ b/lee/state_machine/src/signature/mod.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use k256::ecdsa::signature::hazmat::PrehashVerifier;
 pub use private_key::PrivateKey;
 pub use public_key::PublicKey;
 use rand::{RngCore as _, rngs::OsRng};
@@ -72,7 +73,7 @@ impl Signature {
             return false;
         };
 
-        pk.verify_raw(bytes, &sig).is_ok()
+        pk.verify_prehash(bytes, &sig).is_ok()
     }
 }
 


### PR DESCRIPTION
## 🎯 Purpose

Fuzzy identified a potential issues with function calls for signatures in [PR 514](github.com/logos-blockchain/logos-execution-zone/issues/514).
- Replace `verify_raw` with `verify_prehash`.
- Explicitly add `schnorr` to k256 feature list in cargo.

These are superficial changes.
- `verify_prehash` is a simple wrapper that directly calls `verify_raw` (no additional logic); no risk of signature issues due to the "mismatch" of function calls identified in the issue.
- `schnorr` in feature list as a "defensive" addition.

## ⚙️ Approach

- [X] Replaced `verify_raw` with `verify_prehash`
- [X] Add `k256::schnorr` to Cargo dependencies.

## 🧪 How to Test

Minor refactoring. All previous tests work.

## 🔗 Dependencies

N/A

## 🔜 Future Work

N/A

## 📋 PR Completion Checklist

- [X] Complete PR description
- [X] Implement the core functionality
- ~~[ ] Add/update tests~~
- ~~[ ] Add/update documentation and inline comments~~
