### PR TITLE
refactor(integration_tests): cleaning up long functions

### DIFF
--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -169,9 +169,6 @@ pub fn assert_public_account_restored(ctx: &TestContext, account_id: AccountId, 
         .unwrap_or_else(|| panic!("{label} should be restored"));
 }
 
-/// Maximum time to wait for the indexer to catch up to the sequencer.
-pub const L2_TO_L1_TIMEOUT: Duration = Duration::from_mins(7);
-
 /// Poll the indexer until its last finalized block id reaches the sequencer's
 /// current last block id or until [`L2_TO_L1_TIMEOUT`] elapses.
 /// Returns the last indexer block id observed.

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -6,8 +6,83 @@
 use std::time::Duration;
 
 use anyhow::{Context as _, Result};
+use key_protocol::key_management::key_tree::chain_index::ChainIndex;
+use lee::AccountId;
 use log::info;
 pub use test_fixtures::*;
+use wallet::{
+    cli::{
+        CliAccountMention, Command, SubcommandReturnValue,
+        account::{AccountSubcommand, NewSubcommand},
+        programs::native_token_transfer::AuthTransferSubcommand,
+    },
+    storage::key_chain::FoundPrivateAccount,
+};
+
+/// Create a private or public account at the given chain index and return its ID.
+/// Pass `cci: None` to use the wallet's next available chain index.
+pub async fn new_account(
+    ctx: &mut TestContext,
+    private: bool,
+    cci: Option<ChainIndex>,
+) -> Result<AccountId> {
+    let subcommand = if private {
+        NewSubcommand::Private { cci, label: None }
+    } else {
+        NewSubcommand::Public { cci, label: None }
+    };
+    let result = wallet::cli::execute_subcommand(
+        ctx.wallet_mut(),
+        Command::Account(AccountSubcommand::New(subcommand)),
+    )
+    .await?;
+    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
+        anyhow::bail!("Expected RegisterAccount return value");
+    };
+    Ok(account_id)
+}
+
+/// Send `amount` from `from` to `to` via an authenticated transfer (identifier 0).
+pub async fn send(
+    ctx: &mut TestContext,
+    from: CliAccountMention,
+    to: CliAccountMention,
+    amount: u128,
+) -> Result<()> {
+    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
+        from,
+        to: Some(to),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount,
+    });
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    Ok(())
+}
+
+/// Look up a restored private account for `account_id`, panicking with `label` if absent.
+pub fn restored_private_account<'a>(
+    ctx: &'a TestContext,
+    account_id: AccountId,
+    label: &str,
+) -> FoundPrivateAccount<'a> {
+    ctx.wallet()
+        .storage()
+        .key_chain()
+        .private_account(account_id)
+        .unwrap_or_else(|| panic!("{label} should be restored"))
+}
+
+/// Assert that a restored public account's signing key exists, panicking with `label` if absent.
+pub fn assert_public_account_restored(ctx: &TestContext, account_id: AccountId, label: &str) {
+    ctx.wallet()
+        .storage()
+        .key_chain()
+        .pub_account_signing_key(account_id)
+        .unwrap_or_else(|| panic!("{label} should be restored"));
+}
 
 /// Maximum time to wait for the indexer to catch up to the sequencer.
 pub const L2_TO_L1_TIMEOUT: Duration = Duration::from_mins(7);

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -9,15 +9,21 @@ use anyhow::{Context as _, Result};
 use key_protocol::key_management::key_tree::chain_index::ChainIndex;
 use lee::AccountId;
 use log::info;
+use sequencer_service_rpc::RpcClient as _;
 pub use test_fixtures::*;
 use wallet::{
     cli::{
         CliAccountMention, Command, SubcommandReturnValue,
         account::{AccountSubcommand, NewSubcommand},
-        programs::native_token_transfer::AuthTransferSubcommand,
+        programs::{
+            native_token_transfer::AuthTransferSubcommand, token::TokenProgramAgnosticSubcommand,
+        },
     },
     storage::key_chain::FoundPrivateAccount,
 };
+
+/// Maximum time to wait for the indexer to catch up to the sequencer.
+pub const L2_TO_L1_TIMEOUT: Duration = Duration::from_mins(6);
 
 /// Create a private or public account at the given chain index and return its ID.
 /// Pass `cci: None` to use the wallet's next available chain index.
@@ -62,12 +68,91 @@ pub async fn send(
     Ok(())
 }
 
-/// Look up a restored private account for `account_id`, panicking with `label` if absent.
-pub fn restored_private_account<'a>(
-    ctx: &'a TestContext,
+/// Create a token (New) and wait for the block to be included.
+pub async fn create_token(
+    ctx: &mut TestContext,
+    definition_account_id: CliAccountMention,
+    supply_account_id: CliAccountMention,
+    name: impl Into<String>,
+    total_supply: u128,
+) -> Result<()> {
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id,
+        supply_account_id,
+        name: name.into(),
+        total_supply,
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    Ok(())
+}
+
+/// Send tokens and wait for the block to be included.
+pub async fn token_send(
+    ctx: &mut TestContext,
+    from: CliAccountMention,
+    to: CliAccountMention,
+    amount: u128,
+) -> Result<()> {
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from,
+        to: Some(to),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount,
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    Ok(())
+}
+
+/// Retrieve the native token balance for `account_id`.
+pub async fn account_balance(ctx: &TestContext, account_id: AccountId) -> Result<u128> {
+    Ok(ctx
+        .sequencer_client()
+        .get_account_balance(account_id)
+        .await?)
+}
+
+/// Fetch the full account state for `account_id` from the sequencer.
+pub async fn get_account(ctx: &TestContext, account_id: AccountId) -> Result<lee::Account> {
+    Ok(ctx.sequencer_client().get_account(account_id).await?)
+}
+
+/// Fetch the current commitment for `account_id` and assert it is present in the sequencer state.
+pub async fn assert_private_commitment_in_state(
+    ctx: &TestContext,
     account_id: AccountId,
     label: &str,
-) -> FoundPrivateAccount<'a> {
+) -> Result<()> {
+    let commitment = ctx
+        .wallet()
+        .get_private_account_commitment(account_id)
+        .with_context(|| format!("Failed to get commitment for {label}"))?;
+    assert!(verify_commitment_is_in_state(commitment, ctx.sequencer_client()).await);
+    Ok(())
+}
+
+/// Sync the wallet's private accounts.
+pub async fn sync_private(ctx: &mut TestContext) -> Result<()> {
+    wallet::cli::execute_subcommand(
+        ctx.wallet_mut(),
+        Command::Account(AccountSubcommand::SyncPrivate {}),
+    )
+    .await?;
+    Ok(())
+}
+
+/// Look up a restored private account for `account_id`, panicking with `label` if absent.
+pub fn restored_private_account<'ctx>(
+    ctx: &'ctx TestContext,
+    account_id: AccountId,
+    label: &str,
+) -> FoundPrivateAccount<'ctx> {
     ctx.wallet()
         .storage()
         .key_chain()

--- a/integration_tests/tests/account.rs
+++ b/integration_tests/tests/account.rs
@@ -4,12 +4,11 @@
 )]
 
 use anyhow::{Context as _, Result};
-use integration_tests::{TestContext, private_mention};
+use integration_tests::{TestContext, get_account, new_account, private_mention};
 use key_protocol::key_management::KeyChain;
 use lee::Data;
 use lee_core::account::Nonce;
 use log::info;
-use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
 use wallet::{
     account::{AccountIdWithPrivacy, HumanReadableAccount, Label},
@@ -24,10 +23,7 @@ use wallet::{
 async fn get_existing_account() -> Result<()> {
     let ctx = TestContext::new().await?;
 
-    let account = ctx
-        .sequencer_client()
-        .get_account(ctx.existing_public_accounts()[0])
-        .await?;
+    let account = get_account(&ctx, ctx.existing_public_accounts()[0]).await?;
 
     assert_eq!(
         account.program_owner,
@@ -95,18 +91,7 @@ async fn add_label_to_existing_account() -> Result<()> {
 async fn new_public_account_without_label() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-        cci: None,
-        label: None,
-    }));
-
-    let result = execute_subcommand(ctx.wallet_mut(), command).await?;
-
-    // Extract the account_id from the result
-
-    let wallet::cli::SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        panic!("Expected RegisterAccount return value")
-    };
+    let account_id = new_account(&mut ctx, false, None).await?;
 
     // Verify no label was stored for the account id
     assert!(

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -7,16 +7,18 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, public_mention};
+use integration_tests::{
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, create_token, get_account, new_account,
+    public_mention, token_send,
+};
 use log::info;
-use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
 use wallet::{
     account::Label,
     cli::{
         Command, SubcommandReturnValue,
         account::{AccountSubcommand, NewSubcommand},
-        programs::{amm::AmmProgramAgnosticSubcommand, token::TokenProgramAgnosticSubcommand},
+        programs::amm::AmmProgramAgnosticSubcommand,
     },
 };
 
@@ -43,58 +45,42 @@ async fn amm_public() -> Result<()> {
     let recipient_account_id_2 = new_account(&mut ctx, false, None).await?;
 
     // Create new token
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id_1),
-        supply_account_id: public_mention(supply_account_id_1),
-        name: "A NAM1".to_owned(),
-
-        total_supply: 37,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id_1),
+        public_mention(supply_account_id_1),
+        "A NAM1".to_owned(),
+        37,
+    )
+    .await?;
 
     // Transfer 7 tokens from `supply_acc` to the account at account_id `recipient_account_id_1`
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id_1),
-        to: Some(public_mention(recipient_account_id_1)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 7,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id_1),
+        public_mention(recipient_account_id_1),
+        7,
+    )
+    .await?;
 
     // Create new token
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id_2),
-        supply_account_id: public_mention(supply_account_id_2),
-        name: "A NAM2".to_owned(),
-
-        total_supply: 37,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id_2),
+        public_mention(supply_account_id_2),
+        "A NAM2".to_owned(),
+        37,
+    )
+    .await?;
 
     // Transfer 7 tokens from `supply_acc` to the account at account_id `recipient_account_id_2`
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id_2),
-        to: Some(public_mention(recipient_account_id_2)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 7,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id_2),
+        public_mention(recipient_account_id_2),
+        7,
+    )
+    .await?;
 
     info!("=================== SETUP FINISHED ===============");
 
@@ -117,17 +103,11 @@ async fn amm_public() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let user_holding_a_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_1)
-        .await?;
+    let user_holding_a_acc = get_account(&ctx, recipient_account_id_1).await?;
 
-    let user_holding_b_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_2)
-        .await?;
+    let user_holding_b_acc = get_account(&ctx, recipient_account_id_2).await?;
 
-    let user_holding_lp_acc = ctx.sequencer_client().get_account(user_holding_lp).await?;
+    let user_holding_lp_acc = get_account(&ctx, user_holding_lp).await?;
 
     assert_eq!(
         u128::from_le_bytes(user_holding_a_acc.data[33..].try_into().unwrap()),
@@ -160,17 +140,11 @@ async fn amm_public() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let user_holding_a_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_1)
-        .await?;
+    let user_holding_a_acc = get_account(&ctx, recipient_account_id_1).await?;
 
-    let user_holding_b_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_2)
-        .await?;
+    let user_holding_b_acc = get_account(&ctx, recipient_account_id_2).await?;
 
-    let user_holding_lp_acc = ctx.sequencer_client().get_account(user_holding_lp).await?;
+    let user_holding_lp_acc = get_account(&ctx, user_holding_lp).await?;
 
     assert_eq!(
         u128::from_le_bytes(user_holding_a_acc.data[33..].try_into().unwrap()),
@@ -203,17 +177,11 @@ async fn amm_public() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let user_holding_a_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_1)
-        .await?;
+    let user_holding_a_acc = get_account(&ctx, recipient_account_id_1).await?;
 
-    let user_holding_b_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_2)
-        .await?;
+    let user_holding_b_acc = get_account(&ctx, recipient_account_id_2).await?;
 
-    let user_holding_lp_acc = ctx.sequencer_client().get_account(user_holding_lp).await?;
+    let user_holding_lp_acc = get_account(&ctx, user_holding_lp).await?;
 
     assert_eq!(
         u128::from_le_bytes(user_holding_a_acc.data[33..].try_into().unwrap()),
@@ -247,17 +215,11 @@ async fn amm_public() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let user_holding_a_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_1)
-        .await?;
+    let user_holding_a_acc = get_account(&ctx, recipient_account_id_1).await?;
 
-    let user_holding_b_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_2)
-        .await?;
+    let user_holding_b_acc = get_account(&ctx, recipient_account_id_2).await?;
 
-    let user_holding_lp_acc = ctx.sequencer_client().get_account(user_holding_lp).await?;
+    let user_holding_lp_acc = get_account(&ctx, user_holding_lp).await?;
 
     assert_eq!(
         u128::from_le_bytes(user_holding_a_acc.data[33..].try_into().unwrap()),
@@ -291,17 +253,11 @@ async fn amm_public() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let user_holding_a_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_1)
-        .await?;
+    let user_holding_a_acc = get_account(&ctx, recipient_account_id_1).await?;
 
-    let user_holding_b_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_2)
-        .await?;
+    let user_holding_b_acc = get_account(&ctx, recipient_account_id_2).await?;
 
-    let user_holding_lp_acc = ctx.sequencer_client().get_account(user_holding_lp).await?;
+    let user_holding_lp_acc = get_account(&ctx, user_holding_lp).await?;
 
     assert_eq!(
         u128::from_le_bytes(user_holding_a_acc.data[33..].try_into().unwrap()),
@@ -386,48 +342,40 @@ async fn amm_new_pool_using_labels() -> Result<()> {
     };
 
     // Create token 1 and distribute to holding_a
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id_1),
-        supply_account_id: public_mention(supply_account_id_1),
-        name: "TOKEN1".to_owned(),
-        total_supply: 10,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id_1),
+        public_mention(supply_account_id_1),
+        "TOKEN1".to_owned(),
+        10,
+    )
+    .await?;
 
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id_1),
-        to: Some(public_mention(holding_a_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 5,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id_1),
+        public_mention(holding_a_id),
+        5,
+    )
+    .await?;
 
     // Create token 2 and distribute to holding_b
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id_2),
-        supply_account_id: public_mention(supply_account_id_2),
-        name: "TOKEN2".to_owned(),
-        total_supply: 10,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id_2),
+        public_mention(supply_account_id_2),
+        "TOKEN2".to_owned(),
+        10,
+    )
+    .await?;
 
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id_2),
-        to: Some(public_mention(holding_b_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 5,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id_2),
+        public_mention(holding_b_id),
+        5,
+    )
+    .await?;
 
     // Create AMM pool using account labels instead of IDs
     let subcommand = AmmProgramAgnosticSubcommand::New {
@@ -440,7 +388,7 @@ async fn amm_new_pool_using_labels() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::AMM(subcommand)).await?;
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let holding_lp_acc = ctx.sequencer_client().get_account(holding_lp_id).await?;
+    let holding_lp_acc = get_account(&ctx, holding_lp_id).await?;
 
     // LP balance should be 3 (geometric mean of 3, 3)
     assert_eq!(

--- a/integration_tests/tests/amm.rs
+++ b/integration_tests/tests/amm.rs
@@ -7,7 +7,7 @@
 use std::time::Duration;
 
 use anyhow::Result;
-use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, public_mention};
+use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, public_mention};
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
@@ -25,94 +25,22 @@ async fn amm_public() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create new account for the token definition
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id_1,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id_1 = new_account(&mut ctx, false, None).await?;
 
     // Create new account for the token supply holder
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id_1,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id_1 = new_account(&mut ctx, false, None).await?;
 
     // Create new account for receiving a token transaction
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id_1,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id_1 = new_account(&mut ctx, false, None).await?;
 
     // Create new account for the token definition
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id_2,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id_2 = new_account(&mut ctx, false, None).await?;
 
     // Create new account for the token supply holder
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id_2,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id_2 = new_account(&mut ctx, false, None).await?;
 
     // Create new account for receiving a token transaction
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id_2,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id_2 = new_account(&mut ctx, false, None).await?;
 
     // Create new token
     let subcommand = TokenProgramAgnosticSubcommand::New {
@@ -174,19 +102,7 @@ async fn amm_public() -> Result<()> {
 
     // Setup accounts
     // Create new account for the user holding lp
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: user_holding_lp,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let user_holding_lp = new_account(&mut ctx, false, None).await?;
 
     // Send creation tx
     let subcommand = AmmProgramAgnosticSubcommand::New {
@@ -412,33 +328,9 @@ async fn amm_new_pool_using_labels() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token 1 accounts
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id_1,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id_1 = new_account(&mut ctx, false, None).await?;
 
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id_1,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id_1 = new_account(&mut ctx, false, None).await?;
 
     // Create holding_a with a label
     let holding_a_label = Label::new("amm-holding-a-label");
@@ -457,33 +349,9 @@ async fn amm_new_pool_using_labels() -> Result<()> {
     };
 
     // Create token 2 accounts
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id_2,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id_2 = new_account(&mut ctx, false, None).await?;
 
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id_2,
-    } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id_2 = new_account(&mut ctx, false, None).await?;
 
     // Create holding_b with a label
     let holding_b_label = Label::new("amm-holding-b-label");

--- a/integration_tests/tests/ata.rs
+++ b/integration_tests/tests/ata.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use associated_token_account_core::{compute_ata_seed, get_associated_token_account_id};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, private_mention, public_mention,
     verify_commitment_is_in_state,
 };
 use log::info;
@@ -17,50 +17,17 @@ use sequencer_service_rpc::RpcClient as _;
 use token_core::{TokenDefinition, TokenHolding};
 use tokio::test;
 use wallet::cli::{
-    Command, SubcommandReturnValue,
-    account::{AccountSubcommand, NewSubcommand},
+    Command,
     programs::{ata::AtaSubcommand, token::TokenProgramAgnosticSubcommand},
 };
-
-/// Create a public account and return its ID.
-async fn new_public_account(ctx: &mut TestContext) -> Result<lee::AccountId> {
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
-    Ok(account_id)
-}
-
-/// Create a private account and return its ID.
-async fn new_private_account(ctx: &mut TestContext) -> Result<lee::AccountId> {
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
-    Ok(account_id)
-}
 
 #[test]
 async fn create_ata_initializes_holding_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let owner_account_id = new_public_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let owner_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create a fungible token
     let total_supply = 100_u128;
@@ -121,9 +88,9 @@ async fn create_ata_initializes_holding_account() -> Result<()> {
 async fn create_ata_is_idempotent() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let owner_account_id = new_public_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let owner_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create a fungible token
     wallet::cli::execute_subcommand(
@@ -196,10 +163,10 @@ async fn create_ata_is_idempotent() -> Result<()> {
 async fn transfer_and_burn_via_ata() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let sender_account_id = new_public_account(&mut ctx).await?;
-    let recipient_account_id = new_public_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let sender_account_id = new_account(&mut ctx, false, None).await?;
+    let recipient_account_id = new_account(&mut ctx, false, None).await?;
 
     let total_supply = 1000_u128;
 
@@ -355,9 +322,9 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
 async fn create_ata_with_private_owner() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let owner_account_id = new_private_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let owner_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create a fungible token
     wallet::cli::execute_subcommand(
@@ -424,10 +391,10 @@ async fn create_ata_with_private_owner() -> Result<()> {
 async fn transfer_via_ata_private_owner() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let sender_account_id = new_private_account(&mut ctx).await?;
-    let recipient_account_id = new_public_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let sender_account_id = new_account(&mut ctx, true, None).await?;
+    let recipient_account_id = new_account(&mut ctx, false, None).await?;
 
     let total_supply = 1000_u128;
 
@@ -549,9 +516,9 @@ async fn transfer_via_ata_private_owner() -> Result<()> {
 async fn burn_via_ata_private_owner() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let definition_account_id = new_public_account(&mut ctx).await?;
-    let supply_account_id = new_public_account(&mut ctx).await?;
-    let holder_account_id = new_private_account(&mut ctx).await?;
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
+    let holder_account_id = new_account(&mut ctx, true, None).await?;
 
     let total_supply = 500_u128;
 

--- a/integration_tests/tests/ata.rs
+++ b/integration_tests/tests/ata.rs
@@ -9,17 +9,14 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use associated_token_account_core::{compute_ata_seed, get_associated_token_account_id};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, private_mention, public_mention,
-    verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, create_token, get_account, new_account,
+    private_mention, public_mention, token_send, verify_commitment_is_in_state,
 };
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use token_core::{TokenDefinition, TokenHolding};
 use tokio::test;
-use wallet::cli::{
-    Command,
-    programs::{ata::AtaSubcommand, token::TokenProgramAgnosticSubcommand},
-};
+use wallet::cli::{Command, programs::ata::AtaSubcommand};
 
 #[test]
 async fn create_ata_initializes_holding_account() -> Result<()> {
@@ -31,19 +28,14 @@ async fn create_ata_initializes_holding_account() -> Result<()> {
 
     // Create a fungible token
     let total_supply = 100_u128;
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        total_supply,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Create the ATA for owner + definition
     wallet::cli::execute_subcommand(
@@ -93,19 +85,14 @@ async fn create_ata_is_idempotent() -> Result<()> {
     let owner_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create a fungible token
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply: 100,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        100,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Create the ATA once
     wallet::cli::execute_subcommand(
@@ -171,19 +158,14 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
     let total_supply = 1000_u128;
 
     // Create a fungible token, supply goes to supply_account_id
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        total_supply,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Derive ATA addresses
     let ata_program_id = programs::ata().id();
@@ -219,22 +201,13 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
 
     // Fund sender's ATA from the supply account (direct token transfer)
     let fund_amount = 200_u128;
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::Send {
-            from: public_mention(supply_account_id),
-            to: Some(public_mention(sender_ata_id)),
-            to_npk: None,
-            to_vpk: None,
-            to_keys: None,
-            to_identifier: Some(0),
-            amount: fund_amount,
-        }),
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id),
+        public_mention(sender_ata_id),
+        fund_amount,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Transfer from sender's ATA to recipient's ATA via the ATA program
     let transfer_amount = 50_u128;
@@ -253,7 +226,7 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify sender ATA balance decreased
-    let sender_ata_acc = ctx.sequencer_client().get_account(sender_ata_id).await?;
+    let sender_ata_acc = get_account(&ctx, sender_ata_id).await?;
     let sender_holding = TokenHolding::try_from(&sender_ata_acc.data)?;
     assert_eq!(
         sender_holding,
@@ -264,7 +237,7 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
     );
 
     // Verify recipient ATA balance increased
-    let recipient_ata_acc = ctx.sequencer_client().get_account(recipient_ata_id).await?;
+    let recipient_ata_acc = get_account(&ctx, recipient_ata_id).await?;
     let recipient_holding = TokenHolding::try_from(&recipient_ata_acc.data)?;
     assert_eq!(
         recipient_holding,
@@ -290,7 +263,7 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify sender ATA balance after burn
-    let sender_ata_acc = ctx.sequencer_client().get_account(sender_ata_id).await?;
+    let sender_ata_acc = get_account(&ctx, sender_ata_id).await?;
     let sender_holding = TokenHolding::try_from(&sender_ata_acc.data)?;
     assert_eq!(
         sender_holding,
@@ -301,10 +274,7 @@ async fn transfer_and_burn_via_ata() -> Result<()> {
     );
 
     // Verify the token definition total_supply decreased by burn_amount
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
     assert_eq!(
         token_definition,
@@ -327,19 +297,14 @@ async fn create_ata_with_private_owner() -> Result<()> {
     let owner_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create a fungible token
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply: 100,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        100,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Create the ATA for the private owner + definition
     wallet::cli::execute_subcommand(
@@ -399,19 +364,14 @@ async fn transfer_via_ata_private_owner() -> Result<()> {
     let total_supply = 1000_u128;
 
     // Create a fungible token
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        total_supply,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Derive ATA addresses
     let ata_program_id = programs::ata().id();
@@ -447,22 +407,13 @@ async fn transfer_via_ata_private_owner() -> Result<()> {
 
     // Fund sender's ATA from the supply account (direct token transfer)
     let fund_amount = 200_u128;
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::Send {
-            from: public_mention(supply_account_id),
-            to: Some(public_mention(sender_ata_id)),
-            to_npk: None,
-            to_vpk: None,
-            to_keys: None,
-            to_identifier: Some(0),
-            amount: fund_amount,
-        }),
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id),
+        public_mention(sender_ata_id),
+        fund_amount,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Transfer from sender's ATA (private owner) to recipient's ATA
     let transfer_amount = 50_u128;
@@ -481,7 +432,7 @@ async fn transfer_via_ata_private_owner() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify sender ATA balance decreased
-    let sender_ata_acc = ctx.sequencer_client().get_account(sender_ata_id).await?;
+    let sender_ata_acc = get_account(&ctx, sender_ata_id).await?;
     let sender_holding = TokenHolding::try_from(&sender_ata_acc.data)?;
     assert_eq!(
         sender_holding,
@@ -492,7 +443,7 @@ async fn transfer_via_ata_private_owner() -> Result<()> {
     );
 
     // Verify recipient ATA balance increased
-    let recipient_ata_acc = ctx.sequencer_client().get_account(recipient_ata_id).await?;
+    let recipient_ata_acc = get_account(&ctx, recipient_ata_id).await?;
     let recipient_holding = TokenHolding::try_from(&recipient_ata_acc.data)?;
     assert_eq!(
         recipient_holding,
@@ -523,19 +474,14 @@ async fn burn_via_ata_private_owner() -> Result<()> {
     let total_supply = 500_u128;
 
     // Create a fungible token
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::New {
-            definition_account_id: public_mention(definition_account_id),
-            supply_account_id: public_mention(supply_account_id),
-            name: "TEST".to_owned(),
-            total_supply,
-        }),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "TEST".to_owned(),
+        total_supply,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Derive holder's ATA address
     let ata_program_id = programs::ata().id();
@@ -559,22 +505,13 @@ async fn burn_via_ata_private_owner() -> Result<()> {
 
     // Fund holder's ATA from the supply account
     let fund_amount = 300_u128;
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Token(TokenProgramAgnosticSubcommand::Send {
-            from: public_mention(supply_account_id),
-            to: Some(public_mention(holder_ata_id)),
-            to_npk: None,
-            to_vpk: None,
-            to_keys: None,
-            to_identifier: Some(0),
-            amount: fund_amount,
-        }),
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id),
+        public_mention(holder_ata_id),
+        fund_amount,
     )
     .await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Burn from holder's ATA (private owner)
     let burn_amount = 100_u128;
@@ -592,7 +529,7 @@ async fn burn_via_ata_private_owner() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify holder ATA balance after burn
-    let holder_ata_acc = ctx.sequencer_client().get_account(holder_ata_id).await?;
+    let holder_ata_acc = get_account(&ctx, holder_ata_id).await?;
     let holder_holding = TokenHolding::try_from(&holder_ata_acc.data)?;
     assert_eq!(
         holder_holding,
@@ -603,10 +540,7 @@ async fn burn_via_ata_private_owner() -> Result<()> {
     );
 
     // Verify the token definition total_supply decreased by burn_amount
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
     assert_eq!(
         token_definition,

--- a/integration_tests/tests/auth_transfer/private.rs
+++ b/integration_tests/tests/auth_transfer/private.rs
@@ -3,8 +3,9 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use common::transaction::LeeTransaction;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, fetch_privacy_preserving_tx, new_account,
-    private_mention, public_mention, send, verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance,
+    assert_private_commitment_in_state, fetch_privacy_preserving_tx, get_account, new_account,
+    private_mention, public_mention, send, sync_private, verify_commitment_is_in_state,
 };
 use lee::{
     AccountId, SharedSecretKey, execute_and_prove,
@@ -41,17 +42,8 @@ async fn private_transfer_to_owned_account() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let new_commitment1 = ctx
-        .wallet()
-        .get_private_account_commitment(from)
-        .context("Failed to get private account commitment for sender")?;
-    assert!(verify_commitment_is_in_state(new_commitment1, ctx.sequencer_client()).await);
-
-    let new_commitment2 = ctx
-        .wallet()
-        .get_private_account_commitment(to)
-        .context("Failed to get private account commitment for receiver")?;
-    assert!(verify_commitment_is_in_state(new_commitment2, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, from, "sender").await?;
+    assert_private_commitment_in_state(&ctx, to, "receiver").await?;
 
     info!("Successfully transferred privately to owned account");
 
@@ -126,13 +118,9 @@ async fn deshielded_transfer_to_public_account() -> Result<()> {
         .wallet()
         .get_account_private(from)
         .context("Failed to get sender's private account")?;
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(from)
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, from, "sender").await?;
 
-    let acc_2_balance = ctx.sequencer_client().get_account_balance(to).await?;
+    let acc_2_balance = account_balance(&ctx, to).await?;
 
     assert_eq!(from_acc.balance, 9900);
     assert_eq!(acc_2_balance, 20100);
@@ -178,14 +166,13 @@ async fn private_transfer_to_owned_account_using_claiming_path() -> Result<()> {
     let tx = fetch_privacy_preserving_tx(ctx.sequencer_client(), tx_hash).await;
 
     // Sync the wallet to claim the new account
-    let command = Command::Account(AccountSubcommand::SyncPrivate {});
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
-    let new_commitment1 = ctx
+    let sender_commitment = ctx
         .wallet()
         .get_private_account_commitment(from)
         .context("Failed to get private account commitment for sender")?;
-    assert_eq!(tx.message.new_commitments[0], new_commitment1);
+    assert_eq!(tx.message.new_commitments[0], sender_commitment);
 
     assert_eq!(tx.message.new_commitments.len(), 2);
     for commitment in tx.message.new_commitments {
@@ -219,13 +206,9 @@ async fn shielded_transfer_to_owned_private_account() -> Result<()> {
         .wallet()
         .get_account_private(to)
         .context("Failed to get receiver's private account")?;
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(to)
-        .context("Failed to get receiver's commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, to, "receiver").await?;
 
-    let acc_from_balance = ctx.sequencer_client().get_account_balance(from).await?;
+    let acc_from_balance = account_balance(&ctx, from).await?;
 
     assert_eq!(acc_from_balance, 9900);
     assert_eq!(acc_to.balance, 20100);
@@ -264,7 +247,7 @@ async fn shielded_transfer_to_foreign_account() -> Result<()> {
 
     let tx = fetch_privacy_preserving_tx(ctx.sequencer_client(), tx_hash).await;
 
-    let acc_1_balance = ctx.sequencer_client().get_account_balance(from).await?;
+    let acc_1_balance = account_balance(&ctx, from).await?;
 
     assert!(
         verify_commitment_is_in_state(
@@ -356,14 +339,9 @@ async fn initialize_private_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Syncing private accounts");
-    let command = Command::Account(AccountSubcommand::SyncPrivate {});
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(account_id)
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, account_id, "account").await?;
 
     let account = ctx
         .wallet()
@@ -409,17 +387,8 @@ async fn private_transfer_using_from_label() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let new_commitment1 = ctx
-        .wallet()
-        .get_private_account_commitment(from)
-        .context("Failed to get private account commitment for sender")?;
-    assert!(verify_commitment_is_in_state(new_commitment1, ctx.sequencer_client()).await);
-
-    let new_commitment2 = ctx
-        .wallet()
-        .get_private_account_commitment(to)
-        .context("Failed to get private account commitment for receiver")?;
-    assert!(verify_commitment_is_in_state(new_commitment2, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, from, "sender").await?;
+    assert_private_commitment_in_state(&ctx, to, "receiver").await?;
 
     info!("Successfully transferred privately using from_label");
 
@@ -449,14 +418,9 @@ async fn initialize_private_account_using_label() -> Result<()> {
 
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let command = Command::Account(AccountSubcommand::SyncPrivate {});
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(account_id)
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, account_id, "account").await?;
 
     let account = ctx
         .wallet()
@@ -532,11 +496,7 @@ async fn shielded_transfers_to_two_identifiers_same_npk() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::SyncPrivate {}),
-    )
-    .await?;
+    sync_private(&mut ctx).await?;
 
     // Both accounts must be discovered with the correct balances.
     let account_id_1 = AccountId::for_regular_private_account(&npk, identifier_1);
@@ -611,16 +571,12 @@ async fn ppt_cant_chain_call_faucet() -> Result<()> {
     let amount: u128 = 1;
 
     let faucet_pre = AccountWithMetadata::new(
-        ctx.sequencer_client()
-            .get_account(faucet_account_id)
-            .await?,
+        get_account(&ctx, faucet_account_id).await?,
         false,
         faucet_account_id,
     );
     let vault_pda_pre = AccountWithMetadata::new(
-        ctx.sequencer_client()
-            .get_account(attacker_vault_id)
-            .await?,
+        get_account(&ctx, attacker_vault_id).await?,
         false,
         attacker_vault_id,
     );

--- a/integration_tests/tests/auth_transfer/private.rs
+++ b/integration_tests/tests/auth_transfer/private.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use common::transaction::LeeTransaction;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, fetch_privacy_preserving_tx, private_mention,
-    public_mention, verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, fetch_privacy_preserving_tx, new_account,
+    private_mention, public_mention, send, verify_commitment_is_in_state,
 };
 use lee::{
     AccountId, SharedSecretKey, execute_and_prove,
@@ -36,17 +36,7 @@ async fn private_transfer_to_owned_account() -> Result<()> {
     let from: AccountId = ctx.existing_private_accounts()[0];
     let to: AccountId = ctx.existing_private_accounts()[1];
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(from),
-        to: Some(private_mention(to)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, private_mention(from), private_mention(to), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -127,17 +117,7 @@ async fn deshielded_transfer_to_public_account() -> Result<()> {
         .context("Failed to get sender's private account")?;
     assert_eq!(from_acc.balance, 10000);
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(from),
-        to: Some(public_mention(to)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, private_mention(from), public_mention(to), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -169,18 +149,7 @@ async fn private_transfer_to_owned_account_using_claiming_path() -> Result<()> {
     let from: AccountId = ctx.existing_private_accounts()[0];
 
     // Create a new private account
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: None,
-        label: None,
-    }));
-
-    let sub_ret = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id,
-    } = sub_ret
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let to_account_id = new_account(&mut ctx, true, None).await?;
 
     // Get the keys for the newly created account
     let to = ctx
@@ -241,17 +210,7 @@ async fn shielded_transfer_to_owned_private_account() -> Result<()> {
     let from: AccountId = ctx.existing_public_accounts()[0];
     let to: AccountId = ctx.existing_private_accounts()[1];
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(from),
-        to: Some(private_mention(to)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, public_mention(from), private_mention(to), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -334,18 +293,7 @@ async fn private_transfer_to_owned_account_continuous_run_path() -> Result<()> {
     let from: AccountId = ctx.existing_private_accounts()[0];
 
     // Create a new private account
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: None,
-        label: None,
-    }));
-    let sub_ret = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id,
-    } = sub_ret
-    else {
-        anyhow::bail!("Failed to register account");
-    };
+    let to_account_id = new_account(&mut ctx, true, None).await?;
 
     // Get the newly created account's keys
     let to = ctx
@@ -398,14 +346,7 @@ async fn private_transfer_to_owned_account_continuous_run_path() -> Result<()> {
 async fn initialize_private_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: None,
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let account_id = new_account(&mut ctx, true, None).await?;
 
     let command = Command::AuthTransfer(AuthTransferSubcommand::Init {
         account_id: private_mention(account_id),
@@ -457,17 +398,13 @@ async fn private_transfer_using_from_label() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Send using the label instead of account ID
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: CliAccountMention::Label(label),
-        to: Some(private_mention(to)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(
+        &mut ctx,
+        CliAccountMention::Label(label),
+        private_mention(to),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;

--- a/integration_tests/tests/auth_transfer/public.rs
+++ b/integration_tests/tests/auth_transfer/public.rs
@@ -2,16 +2,17 @@ use std::time::Duration;
 
 use anyhow::Result;
 use common::transaction::LeeTransaction;
-use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, public_mention};
-use lee::public_transaction;
+use integration_tests::{
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, public_mention, send,
+};
+use lee::{program::Program, public_transaction, system_faucet_account_id};
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
 use wallet::{
     account::Label,
     cli::{
-        CliAccountMention, Command, SubcommandReturnValue,
-        account::{AccountSubcommand, NewSubcommand},
+        CliAccountMention, Command, account::AccountSubcommand,
         programs::native_token_transfer::AuthTransferSubcommand,
     },
 };
@@ -19,18 +20,12 @@ use wallet::{
 #[test]
 async fn successful_transfer_to_existing_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
+    let (acc0, acc1) = (
+        ctx.existing_public_accounts()[0],
+        ctx.existing_public_accounts()[1],
+    );
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(public_mention(ctx.existing_public_accounts()[1])),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -58,38 +53,16 @@ async fn successful_transfer_to_existing_account() -> Result<()> {
 pub async fn successful_transfer_to_new_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-        cci: None,
-        label: None,
-    }));
+    let new_persistent_account_id = new_account(&mut ctx, false, None).await?;
+    let acc0 = ctx.existing_public_accounts()[0];
 
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command)
-        .await
-        .unwrap();
-
-    let new_persistent_account_id = ctx
-        .wallet()
-        .storage()
-        .key_chain()
-        .public_account_ids()
-        .map(|(account_id, _)| account_id)
-        .find(|acc_id| {
-            *acc_id != ctx.existing_public_accounts()[0]
-                && *acc_id != ctx.existing_public_accounts()[1]
-        })
-        .expect("Failed to find newly created account in the wallet storage");
-
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(public_mention(new_persistent_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(
+        &mut ctx,
+        public_mention(acc0),
+        public_mention(new_persistent_account_id),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -155,19 +128,13 @@ async fn failed_transfer_with_insufficient_balance() -> Result<()> {
 #[test]
 async fn two_consecutive_successful_transfers() -> Result<()> {
     let mut ctx = TestContext::new().await?;
+    let (acc0, acc1) = (
+        ctx.existing_public_accounts()[0],
+        ctx.existing_public_accounts()[1],
+    );
 
     // First transfer
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(public_mention(ctx.existing_public_accounts()[1])),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -191,17 +158,7 @@ async fn two_consecutive_successful_transfers() -> Result<()> {
     info!("First TX Success!");
 
     // Second transfer
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(public_mention(ctx.existing_public_accounts()[1])),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -231,14 +188,7 @@ async fn two_consecutive_successful_transfers() -> Result<()> {
 async fn initialize_public_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-        cci: None,
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let account_id = new_account(&mut ctx, false, None).await?;
 
     let command = Command::AuthTransfer(AuthTransferSubcommand::Init {
         account_id: public_mention(account_id),
@@ -274,17 +224,14 @@ async fn successful_transfer_using_from_label() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Send using the label instead of account ID
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: CliAccountMention::Label(label),
-        to: Some(public_mention(ctx.existing_public_accounts()[1])),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    let acc1 = ctx.existing_public_accounts()[1];
+    send(
+        &mut ctx,
+        CliAccountMention::Label(label),
+        public_mention(acc1),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
@@ -320,17 +267,14 @@ async fn successful_transfer_using_to_label() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Send using the label for the recipient
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(CliAccountMention::Label(label)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    let acc0 = ctx.existing_public_accounts()[0];
+    send(
+        &mut ctx,
+        public_mention(acc0),
+        CliAccountMention::Label(label),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;

--- a/integration_tests/tests/auth_transfer/public.rs
+++ b/integration_tests/tests/auth_transfer/public.rs
@@ -3,7 +3,8 @@ use std::time::Duration;
 use anyhow::Result;
 use common::transaction::LeeTransaction;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, public_mention, send,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance, get_account, new_account,
+    public_mention, send,
 };
 use lee::{program::Program, public_transaction, system_faucet_account_id};
 use log::info;
@@ -31,14 +32,8 @@ async fn successful_transfer_to_existing_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -68,14 +63,8 @@ pub async fn successful_transfer_to_new_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(new_persistent_account_id)
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, new_persistent_account_id).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -107,14 +96,8 @@ async fn failed_transfer_with_insufficient_balance() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking balances unchanged");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -140,14 +123,8 @@ async fn two_consecutive_successful_transfers() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move after first transfer");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -164,14 +141,8 @@ async fn two_consecutive_successful_transfers() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move after second transfer");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -196,7 +167,7 @@ async fn initialize_public_account() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     info!("Checking correct execution");
-    let account = ctx.sequencer_client().get_account(account_id).await?;
+    let account = get_account(&ctx, account_id).await?;
 
     assert_eq!(
         account.program_owner,
@@ -237,14 +208,8 @@ async fn successful_transfer_using_from_label() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     assert_eq!(acc_1_balance, 9900);
     assert_eq!(acc_2_balance, 20100);
@@ -280,14 +245,8 @@ async fn successful_transfer_using_to_label() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
-    let acc_2_balance = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[1])
-        .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     assert_eq!(acc_1_balance, 9900);
     assert_eq!(acc_2_balance, 20100);
@@ -303,14 +262,8 @@ async fn cannot_transfer_funds_from_system_faucet_account() -> Result<()> {
     let faucet_account_id = system_accounts::faucet_account_id();
 
     let recipient = ctx.existing_public_accounts()[0];
-    let recipient_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient)
-        .await?;
-    let faucet_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
+    let recipient_balance_before = account_balance(&ctx, recipient).await?;
+    let faucet_balance_before = account_balance(&ctx, faucet_account_id).await?;
 
     let amount = 1_u128;
     let message = public_transaction::Message::try_new(
@@ -331,14 +284,8 @@ async fn cannot_transfer_funds_from_system_faucet_account() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let recipient_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(recipient)
-        .await?;
-    let faucet_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
+    let recipient_balance_after = account_balance(&ctx, recipient).await?;
+    let faucet_balance_after = account_balance(&ctx, faucet_account_id).await?;
     let tx_on_chain = ctx.sequencer_client().get_transaction(tx_hash).await?;
 
     assert_eq!(recipient_balance_after, recipient_balance_before);
@@ -357,14 +304,8 @@ async fn cannot_execute_faucet_program() -> Result<()> {
     let vault_program_id = programs::vault().id();
     let recipient_vault_id = vault_core::compute_vault_account_id(vault_program_id, recipient);
 
-    let recipient_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient)
-        .await?;
-    let faucet_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
+    let recipient_balance_before = account_balance(&ctx, recipient).await?;
+    let faucet_balance_before = account_balance(&ctx, faucet_account_id).await?;
 
     let amount = 1_u128;
     let message = public_transaction::Message::try_new(
@@ -389,14 +330,8 @@ async fn cannot_execute_faucet_program() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let recipient_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(recipient)
-        .await?;
-    let faucet_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
+    let recipient_balance_after = account_balance(&ctx, recipient).await?;
+    let faucet_balance_after = account_balance(&ctx, faucet_account_id).await?;
     let tx_on_chain = ctx.sequencer_client().get_transaction(tx_hash).await?;
 
     assert_eq!(recipient_balance_after, recipient_balance_before);
@@ -437,28 +372,16 @@ async fn user_tx_that_chain_calls_faucet_is_dropped() -> Result<()> {
         lee::public_transaction::WitnessSet::from_raw_parts(vec![]),
     ));
 
-    let faucet_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
-    let vault_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(attacker_vault_id)
-        .await?;
+    let faucet_balance_before = account_balance(&ctx, faucet_account_id).await?;
+    let vault_balance_before = account_balance(&ctx, attacker_vault_id).await?;
 
     let tx_hash = ctx.sequencer_client().send_transaction(attack_tx).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let faucet_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(faucet_account_id)
-        .await?;
-    let vault_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(attacker_vault_id)
-        .await?;
+    let faucet_balance_after = account_balance(&ctx, faucet_account_id).await?;
+    let vault_balance_after = account_balance(&ctx, attacker_vault_id).await?;
     let tx_on_chain = ctx.sequencer_client().get_transaction(tx_hash).await?;
 
     assert_eq!(faucet_balance_after, faucet_balance_before);

--- a/integration_tests/tests/auth_transfer/public.rs
+++ b/integration_tests/tests/auth_transfer/public.rs
@@ -6,7 +6,7 @@ use integration_tests::{
     TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance, get_account, new_account,
     public_mention, send,
 };
-use lee::{program::Program, public_transaction, system_faucet_account_id};
+use lee::public_transaction;
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
@@ -21,19 +21,23 @@ use wallet::{
 #[test]
 async fn successful_transfer_to_existing_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
-    let (acc0, acc1) = (
-        ctx.existing_public_accounts()[0],
-        ctx.existing_public_accounts()[1],
-    );
 
-    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
+    let sender = ctx.existing_public_accounts()[0];
+    let receiver = ctx.existing_public_accounts()[1];
+    send(
+        &mut ctx,
+        public_mention(sender),
+        public_mention(receiver),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
-    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
+    let acc_2_balance = account_balance(&ctx, receiver).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -49,11 +53,11 @@ pub async fn successful_transfer_to_new_account() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     let new_persistent_account_id = new_account(&mut ctx, false, None).await?;
-    let acc0 = ctx.existing_public_accounts()[0];
 
+    let sender = ctx.existing_public_accounts()[0];
     send(
         &mut ctx,
-        public_mention(acc0),
+        public_mention(sender),
         public_mention(new_persistent_account_id),
         100,
     )
@@ -63,7 +67,7 @@ pub async fn successful_transfer_to_new_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
     let acc_2_balance = account_balance(&ctx, new_persistent_account_id).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
@@ -111,20 +115,25 @@ async fn failed_transfer_with_insufficient_balance() -> Result<()> {
 #[test]
 async fn two_consecutive_successful_transfers() -> Result<()> {
     let mut ctx = TestContext::new().await?;
-    let (acc0, acc1) = (
-        ctx.existing_public_accounts()[0],
-        ctx.existing_public_accounts()[1],
-    );
+
+    let sender = ctx.existing_public_accounts()[0];
+    let receiver = ctx.existing_public_accounts()[1];
 
     // First transfer
-    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
+    send(
+        &mut ctx,
+        public_mention(sender),
+        public_mention(receiver),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move after first transfer");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
-    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
+    let acc_2_balance = account_balance(&ctx, receiver).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -135,14 +144,20 @@ async fn two_consecutive_successful_transfers() -> Result<()> {
     info!("First TX Success!");
 
     // Second transfer
-    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
+    send(
+        &mut ctx,
+        public_mention(sender),
+        public_mention(receiver),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move after second transfer");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
-    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
+    let acc_2_balance = account_balance(&ctx, receiver).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -195,11 +210,12 @@ async fn successful_transfer_using_from_label() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Send using the label instead of account ID
-    let acc1 = ctx.existing_public_accounts()[1];
+    let sender = ctx.existing_public_accounts()[0];
+    let receiver = ctx.existing_public_accounts()[1];
     send(
         &mut ctx,
         CliAccountMention::Label(label),
-        public_mention(acc1),
+        public_mention(receiver),
         100,
     )
     .await?;
@@ -208,8 +224,8 @@ async fn successful_transfer_using_from_label() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
-    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
+    let acc_2_balance = account_balance(&ctx, receiver).await?;
 
     assert_eq!(acc_1_balance, 9900);
     assert_eq!(acc_2_balance, 20100);
@@ -232,10 +248,11 @@ async fn successful_transfer_using_to_label() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     // Send using the label for the recipient
-    let acc0 = ctx.existing_public_accounts()[0];
+    let sender = ctx.existing_public_accounts()[0];
+    let receiver = ctx.existing_public_accounts()[1];
     send(
         &mut ctx,
-        public_mention(acc0),
+        public_mention(sender),
         CliAccountMention::Label(label),
         100,
     )
@@ -245,8 +262,8 @@ async fn successful_transfer_using_to_label() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
-    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
+    let acc_1_balance = account_balance(&ctx, sender).await?;
+    let acc_2_balance = account_balance(&ctx, receiver).await?;
 
     assert_eq!(acc_1_balance, 9900);
     assert_eq!(acc_2_balance, 20100);

--- a/integration_tests/tests/bridge.rs
+++ b/integration_tests/tests/bridge.rs
@@ -11,7 +11,8 @@ use borsh::BorshSerialize;
 use common::transaction::LeeTransaction;
 use futures::StreamExt as _;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, wait_for_indexer_to_catch_up,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance, get_account,
+    wait_for_indexer_to_catch_up,
 };
 use lee::{
     AccountId, execute_and_prove, privacy_preserving_transaction, program::Program,
@@ -65,27 +66,15 @@ async fn public_bridge_deposit_invocation_is_dropped() -> anyhow::Result<()> {
         lee::public_transaction::WitnessSet::from_raw_parts(vec![]),
     ));
 
-    let bridge_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(bridge_account_id)
-        .await?;
-    let vault_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
+    let bridge_balance_before = account_balance(&ctx, bridge_account_id).await?;
+    let vault_balance_before = account_balance(&ctx, recipient_vault_id).await?;
 
     let tx_hash = ctx.sequencer_client().send_transaction(attack_tx).await?;
 
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let bridge_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(bridge_account_id)
-        .await?;
-    let vault_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
+    let bridge_balance_after = account_balance(&ctx, bridge_account_id).await?;
+    let vault_balance_after = account_balance(&ctx, recipient_vault_id).await?;
     let tx_on_chain = ctx.sequencer_client().get_transaction(tx_hash).await?;
 
     assert_eq!(bridge_balance_after, bridge_balance_before);
@@ -169,16 +158,12 @@ async fn private_bridge_deposit_invocation_is_dropped() -> anyhow::Result<()> {
 
     // Get pre-state of bridge and vault accounts
     let bridge_pre = AccountWithMetadata::new(
-        ctx.sequencer_client()
-            .get_account(bridge_account_id)
-            .await?,
+        get_account(&ctx, bridge_account_id).await?,
         false,
         bridge_account_id,
     );
     let vault_pre = AccountWithMetadata::new(
-        ctx.sequencer_client()
-            .get_account(recipient_vault_id)
-            .await?,
+        get_account(&ctx, recipient_vault_id).await?,
         false,
         recipient_vault_id,
     );
@@ -229,27 +214,15 @@ async fn private_bridge_deposit_invocation_is_dropped() -> anyhow::Result<()> {
         witness_set,
     ));
 
-    let bridge_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(bridge_account_id)
-        .await?;
-    let vault_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
+    let bridge_balance_before = account_balance(&ctx, bridge_account_id).await?;
+    let vault_balance_before = account_balance(&ctx, recipient_vault_id).await?;
 
     let tx_hash = ctx.sequencer_client().send_transaction(attack_tx).await?;
 
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let bridge_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(bridge_account_id)
-        .await?;
-    let vault_balance_after = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
+    let bridge_balance_after = account_balance(&ctx, bridge_account_id).await?;
+    let vault_balance_after = account_balance(&ctx, recipient_vault_id).await?;
     let tx_on_chain = ctx.sequencer_client().get_transaction(tx_hash).await?;
 
     assert_eq!(bridge_balance_after, bridge_balance_before);
@@ -421,7 +394,7 @@ async fn wait_for_vault_balance(
         + Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS);
     tokio::time::timeout(timeout, async {
         loop {
-            let balance = ctx.sequencer_client().get_account_balance(vault_id).await?;
+            let balance = account_balance(ctx, vault_id).await?;
             if balance == expected_balance {
                 return Ok(());
             }
@@ -449,14 +422,8 @@ async fn bedrock_deposit_claim_and_withdraw_round_trip_succeeds() -> anyhow::Res
     let vault_program_id = programs::vault().id();
     let recipient_vault_id = vault_core::compute_vault_account_id(vault_program_id, recipient_id);
 
-    let vault_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
-    let recipient_balance_before = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_id)
-        .await?;
+    let vault_balance_before = account_balance(&ctx, recipient_vault_id).await?;
+    let recipient_balance_before = account_balance(&ctx, recipient_id).await?;
 
     // Submit deposit to Bedrock
     submit_bedrock_deposit(ctx.bedrock_addr(), bedrock_account_pk, recipient_id, amount)
@@ -507,14 +474,8 @@ async fn bedrock_deposit_claim_and_withdraw_round_trip_succeeds() -> anyhow::Res
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     let claim_on_chain = ctx.sequencer_client().get_transaction(claim_hash).await?;
-    let vault_balance_after_claim = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_vault_id)
-        .await?;
-    let recipient_balance_after_claim = ctx
-        .sequencer_client()
-        .get_account_balance(recipient_id)
-        .await?;
+    let vault_balance_after_claim = account_balance(&ctx, recipient_vault_id).await?;
+    let recipient_balance_after_claim = account_balance(&ctx, recipient_id).await?;
 
     assert!(
         claim_on_chain.is_some(),
@@ -543,7 +504,7 @@ async fn bedrock_deposit_claim_and_withdraw_round_trip_succeeds() -> anyhow::Res
             account_id.into(),
         )
         .await?;
-        let sequencer_account = ctx.sequencer_client().get_account(account_id).await?;
+        let sequencer_account = get_account(&ctx, account_id).await?;
         assert_eq!(
             indexer_account,
             sequencer_account.into(),

--- a/integration_tests/tests/indexer_state_consistency.rs
+++ b/integration_tests/tests/indexer_state_consistency.rs
@@ -1,51 +1,36 @@
 #![expect(
-    clippy::shadow_unrelated,
     clippy::tests_outside_test_module,
     reason = "We don't care about these in tests"
 )]
 
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
 use indexer_service_rpc::RpcClient as _;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
-    verify_commitment_is_in_state, wait_for_indexer_to_catch_up,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance,
+    assert_private_commitment_in_state, get_account, private_mention, public_mention, send,
+    wait_for_indexer_to_catch_up,
 };
 use lee::AccountId;
 use log::info;
-use wallet::cli::{Command, programs::native_token_transfer::AuthTransferSubcommand};
 
 #[tokio::test]
 async fn indexer_state_consistency() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(ctx.existing_public_accounts()[0]),
-        to: Some(public_mention(ctx.existing_public_accounts()[1])),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    let (acc0, acc1) = (
+        ctx.existing_public_accounts()[0],
+        ctx.existing_public_accounts()[1],
+    );
+    send(&mut ctx, public_mention(acc0), public_mention(acc1), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let acc_1_balance = sequencer_service_rpc::RpcClient::get_account_balance(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[0],
-    )
-    .await?;
-    let acc_2_balance = sequencer_service_rpc::RpcClient::get_account_balance(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[1],
-    )
-    .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     info!("Balance of sender: {acc_1_balance:#?}");
     info!("Balance of receiver: {acc_2_balance:#?}");
@@ -56,32 +41,13 @@ async fn indexer_state_consistency() -> Result<()> {
     let from: AccountId = ctx.existing_private_accounts()[0];
     let to: AccountId = ctx.existing_private_accounts()[1];
 
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(from),
-        to: Some(private_mention(to)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(&mut ctx, private_mention(from), private_mention(to), 100).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let new_commitment1 = ctx
-        .wallet()
-        .get_private_account_commitment(from)
-        .context("Failed to get private account commitment for sender")?;
-    assert!(verify_commitment_is_in_state(new_commitment1, ctx.sequencer_client()).await);
-
-    let new_commitment2 = ctx
-        .wallet()
-        .get_private_account_commitment(to)
-        .context("Failed to get private account commitment for receiver")?;
-    assert!(verify_commitment_is_in_state(new_commitment2, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, from, "sender").await?;
+    assert_private_commitment_in_state(&ctx, to, "receiver").await?;
 
     info!("Successfully transferred privately to owned account");
 
@@ -100,16 +66,8 @@ async fn indexer_state_consistency() -> Result<()> {
         .unwrap();
 
     info!("Checking correct state transition");
-    let acc1_seq_state = sequencer_service_rpc::RpcClient::get_account(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[0],
-    )
-    .await?;
-    let acc2_seq_state = sequencer_service_rpc::RpcClient::get_account(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[1],
-    )
-    .await?;
+    let acc1_seq_state = get_account(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc2_seq_state = get_account(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     assert_eq!(acc1_ind_state, acc1_seq_state.into());
     assert_eq!(acc2_ind_state, acc2_seq_state.into());

--- a/integration_tests/tests/indexer_state_consistency_with_labels.rs
+++ b/integration_tests/tests/indexer_state_consistency_with_labels.rs
@@ -9,12 +9,13 @@ use std::time::Duration;
 use anyhow::Result;
 use indexer_service_rpc::RpcClient as _;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, public_mention, wait_for_indexer_to_catch_up,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance, get_account, public_mention,
+    send, wait_for_indexer_to_catch_up,
 };
 use log::info;
 use wallet::{
     account::Label,
-    cli::{CliAccountMention, Command, programs::native_token_transfer::AuthTransferSubcommand},
+    cli::{CliAccountMention, Command},
 };
 
 #[tokio::test]
@@ -38,31 +39,19 @@ async fn indexer_state_consistency_with_labels() -> Result<()> {
     wallet::cli::execute_subcommand(ctx.wallet_mut(), label_cmd).await?;
 
     // Send using labels instead of account IDs
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: CliAccountMention::Label(from_label),
-        to: Some(CliAccountMention::Label(to_label)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(
+        &mut ctx,
+        CliAccountMention::Label(from_label),
+        CliAccountMention::Label(to_label),
+        100,
+    )
+    .await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let acc_1_balance = sequencer_service_rpc::RpcClient::get_account_balance(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[0],
-    )
-    .await?;
-    let acc_2_balance = sequencer_service_rpc::RpcClient::get_account_balance(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[1],
-    )
-    .await?;
+    let acc_1_balance = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
+    let acc_2_balance = account_balance(&ctx, ctx.existing_public_accounts()[1]).await?;
 
     assert_eq!(acc_1_balance, 9900);
     assert_eq!(acc_2_balance, 20100);
@@ -75,11 +64,7 @@ async fn indexer_state_consistency_with_labels() -> Result<()> {
         .get_account(ctx.existing_public_accounts()[0].into())
         .await
         .unwrap();
-    let acc1_seq_state = sequencer_service_rpc::RpcClient::get_account(
-        ctx.sequencer_client(),
-        ctx.existing_public_accounts()[0],
-    )
-    .await?;
+    let acc1_seq_state = get_account(&ctx, ctx.existing_public_accounts()[0]).await?;
 
     assert_eq!(acc1_ind_state, acc1_seq_state.into());
 

--- a/integration_tests/tests/keys.rs
+++ b/integration_tests/tests/keys.rs
@@ -8,88 +8,19 @@ use std::{str::FromStr as _, time::Duration};
 
 use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, fetch_privacy_preserving_tx, private_mention,
-    public_mention, verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, assert_public_account_restored,
+    fetch_privacy_preserving_tx, new_account, private_mention, public_mention,
+    restored_private_account, send, verify_commitment_is_in_state,
 };
 use key_protocol::key_management::key_tree::chain_index::ChainIndex;
 use lee::AccountId;
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
-use wallet::{
-    cli::{
-        CliAccountMention, Command, SubcommandReturnValue,
-        account::{AccountSubcommand, NewSubcommand},
-        programs::native_token_transfer::AuthTransferSubcommand,
-    },
-    storage::key_chain::FoundPrivateAccount,
+use wallet::cli::{
+    Command, SubcommandReturnValue, account::AccountSubcommand,
+    programs::native_token_transfer::AuthTransferSubcommand,
 };
-
-/// Create a private or public account at the given chain index and return its ID.
-async fn new_account(ctx: &mut TestContext, private: bool, cci: ChainIndex) -> Result<AccountId> {
-    let subcommand = if private {
-        NewSubcommand::Private {
-            cci: Some(cci),
-            label: None,
-        }
-    } else {
-        NewSubcommand::Public {
-            cci: Some(cci),
-            label: None,
-        }
-    };
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(subcommand)),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
-    Ok(account_id)
-}
-
-/// Send `amount` from `from` to `to` via an authenticated transfer (identifier 0).
-async fn send(
-    ctx: &mut TestContext,
-    from: CliAccountMention,
-    to: CliAccountMention,
-    amount: u128,
-) -> Result<()> {
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from,
-        to: Some(to),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    Ok(())
-}
-
-/// Look up the restored private account for `account_id`, asserting it exists.
-fn restored_private_account<'a>(
-    ctx: &'a TestContext,
-    account_id: AccountId,
-    label: &str,
-) -> FoundPrivateAccount<'a> {
-    ctx.wallet()
-        .storage()
-        .key_chain()
-        .private_account(account_id)
-        .unwrap_or_else(|| panic!("{label} should be restored"))
-}
-
-/// Assert that a restored public account's signing key exists.
-fn assert_public_account_restored(ctx: &TestContext, account_id: AccountId, label: &str) {
-    ctx.wallet()
-        .storage()
-        .key_chain()
-        .pub_account_signing_key(account_id)
-        .unwrap_or_else(|| panic!("{label} should be restored"));
-}
 
 #[test]
 async fn sync_private_account_with_non_zero_chain_index() -> Result<()> {
@@ -97,35 +28,12 @@ async fn sync_private_account_with_non_zero_chain_index() -> Result<()> {
 
     let from: AccountId = ctx.existing_private_accounts()[0];
 
-    // Create a new private account
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: None,
-        label: None,
-    }));
-
+    // Key Tree shift — create 3 accounts to advance the key index
     for _ in 0..3 {
-        // Key Tree shift
-        // This way we have account with child index > 0.
-        let result = wallet::cli::execute_subcommand(
-            ctx.wallet_mut(),
-            Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-                cci: None,
-                label: None,
-            })),
-        )
-        .await?;
-        let SubcommandReturnValue::RegisterAccount { account_id: _ } = result else {
-            anyhow::bail!("Expected RegisterAccount return value");
-        };
+        new_account(&mut ctx, true, None).await?;
     }
 
-    let sub_ret = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id,
-    } = sub_ret
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let to_account_id = new_account(&mut ctx, true, None).await?;
 
     // Get the keys for the newly created account
     let to_account = ctx
@@ -188,8 +96,8 @@ async fn restore_keys_from_seed() -> Result<()> {
     let from: AccountId = ctx.existing_private_accounts()[0];
 
     // Create private accounts at root and /0
-    let to_account_id1 = new_account(&mut ctx, true, ChainIndex::root()).await?;
-    let to_account_id2 = new_account(&mut ctx, true, ChainIndex::from_str("/0")?).await?;
+    let to_account_id1 = new_account(&mut ctx, true, Some(ChainIndex::root())).await?;
+    let to_account_id2 = new_account(&mut ctx, true, Some(ChainIndex::from_str("/0")?)).await?;
 
     // Send to both private accounts
     send(
@@ -210,8 +118,8 @@ async fn restore_keys_from_seed() -> Result<()> {
     let from: AccountId = ctx.existing_public_accounts()[0];
 
     // Create public accounts at root and /0
-    let to_account_id3 = new_account(&mut ctx, false, ChainIndex::root()).await?;
-    let to_account_id4 = new_account(&mut ctx, false, ChainIndex::from_str("/0")?).await?;
+    let to_account_id3 = new_account(&mut ctx, false, Some(ChainIndex::root())).await?;
+    let to_account_id4 = new_account(&mut ctx, false, Some(ChainIndex::from_str("/0")?)).await?;
 
     // Send to both public accounts
     send(

--- a/integration_tests/tests/keys.rs
+++ b/integration_tests/tests/keys.rs
@@ -16,11 +16,80 @@ use lee::AccountId;
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
-use wallet::cli::{
-    Command, SubcommandReturnValue,
-    account::{AccountSubcommand, NewSubcommand},
-    programs::native_token_transfer::AuthTransferSubcommand,
+use wallet::{
+    cli::{
+        CliAccountMention, Command, SubcommandReturnValue,
+        account::{AccountSubcommand, NewSubcommand},
+        programs::native_token_transfer::AuthTransferSubcommand,
+    },
+    storage::key_chain::FoundPrivateAccount,
 };
+
+/// Create a private or public account at the given chain index and return its ID.
+async fn new_account(ctx: &mut TestContext, private: bool, cci: ChainIndex) -> Result<AccountId> {
+    let subcommand = if private {
+        NewSubcommand::Private {
+            cci: Some(cci),
+            label: None,
+        }
+    } else {
+        NewSubcommand::Public {
+            cci: Some(cci),
+            label: None,
+        }
+    };
+    let result = wallet::cli::execute_subcommand(
+        ctx.wallet_mut(),
+        Command::Account(AccountSubcommand::New(subcommand)),
+    )
+    .await?;
+    let SubcommandReturnValue::RegisterAccount { account_id } = result else {
+        anyhow::bail!("Expected RegisterAccount return value");
+    };
+    Ok(account_id)
+}
+
+/// Send `amount` from `from` to `to` via an authenticated transfer (identifier 0).
+async fn send(
+    ctx: &mut TestContext,
+    from: CliAccountMention,
+    to: CliAccountMention,
+    amount: u128,
+) -> Result<()> {
+    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
+        from,
+        to: Some(to),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount,
+    });
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    Ok(())
+}
+
+/// Look up the restored private account for `account_id`, asserting it exists.
+fn restored_private_account<'a>(
+    ctx: &'a TestContext,
+    account_id: AccountId,
+    label: &str,
+) -> FoundPrivateAccount<'a> {
+    ctx.wallet()
+        .storage()
+        .key_chain()
+        .private_account(account_id)
+        .unwrap_or_else(|| panic!("{label} should be restored"))
+}
+
+/// Assert that a restored public account's signing key exists.
+fn assert_public_account_restored(ctx: &TestContext, account_id: AccountId, label: &str) {
+    ctx.wallet()
+        .storage()
+        .key_chain()
+        .pub_account_signing_key(account_id)
+        .unwrap_or_else(|| panic!("{label} should be restored"));
+}
 
 #[test]
 async fn sync_private_account_with_non_zero_chain_index() -> Result<()> {
@@ -118,107 +187,47 @@ async fn restore_keys_from_seed() -> Result<()> {
 
     let from: AccountId = ctx.existing_private_accounts()[0];
 
-    // Create first private account at root
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: Some(ChainIndex::root()),
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id1,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    // Create private accounts at root and /0
+    let to_account_id1 = new_account(&mut ctx, true, ChainIndex::root()).await?;
+    let to_account_id2 = new_account(&mut ctx, true, ChainIndex::from_str("/0")?).await?;
 
-    // Create second private account at /0
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-        cci: Some(ChainIndex::from_str("/0")?),
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id2,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
-
-    // Send to first private account
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(from),
-        to: Some(private_mention(to_account_id1)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 100,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-
-    // Send to second private account
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(from),
-        to: Some(private_mention(to_account_id2)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 101,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    // Send to both private accounts
+    send(
+        &mut ctx,
+        private_mention(from),
+        private_mention(to_account_id1),
+        100,
+    )
+    .await?;
+    send(
+        &mut ctx,
+        private_mention(from),
+        private_mention(to_account_id2),
+        101,
+    )
+    .await?;
 
     let from: AccountId = ctx.existing_public_accounts()[0];
 
-    // Create first public account at root
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-        cci: Some(ChainIndex::root()),
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id3,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    // Create public accounts at root and /0
+    let to_account_id3 = new_account(&mut ctx, false, ChainIndex::root()).await?;
+    let to_account_id4 = new_account(&mut ctx, false, ChainIndex::from_str("/0")?).await?;
 
-    // Create second public account at /0
-    let command = Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-        cci: Some(ChainIndex::from_str("/0")?),
-        label: None,
-    }));
-    let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: to_account_id4,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
-
-    // Send to first public account
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(from),
-        to: Some(public_mention(to_account_id3)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 102,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-
-    // Send to second public account
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(from),
-        to: Some(public_mention(to_account_id4)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 103,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    // Send to both public accounts
+    send(
+        &mut ctx,
+        public_mention(from),
+        public_mention(to_account_id3),
+        102,
+    )
+    .await?;
+    send(
+        &mut ctx,
+        public_mention(from),
+        public_mention(to_account_id4),
+        103,
+    )
+    .await?;
 
     info!("Preparation complete, performing keys restoration");
 
@@ -226,34 +235,12 @@ async fn restore_keys_from_seed() -> Result<()> {
     wallet::cli::execute_keys_restoration(ctx.wallet_mut(), 10).await?;
 
     // Verify restored private accounts
-    let acc1 = ctx
-        .wallet()
-        .storage()
-        .key_chain()
-        .private_account(to_account_id1)
-        .expect("Acc 1 should be restored");
-
-    let acc2 = ctx
-        .wallet()
-        .storage()
-        .key_chain()
-        .private_account(to_account_id2)
-        .expect("Acc 2 should be restored");
+    let acc1 = restored_private_account(&ctx, to_account_id1, "Acc 1");
+    let acc2 = restored_private_account(&ctx, to_account_id2, "Acc 2");
 
     // Verify restored public accounts
-    let _acc3 = ctx
-        .wallet()
-        .storage()
-        .key_chain()
-        .pub_account_signing_key(to_account_id3)
-        .expect("Acc 3 should be restored");
-
-    let _acc4 = ctx
-        .wallet()
-        .storage()
-        .key_chain()
-        .pub_account_signing_key(to_account_id4)
-        .expect("Acc 4 should be restored");
+    assert_public_account_restored(&ctx, to_account_id3, "Acc 3");
+    assert_public_account_restored(&ctx, to_account_id4, "Acc 4");
 
     assert_eq!(
         acc1.account.program_owner,
@@ -270,27 +257,20 @@ async fn restore_keys_from_seed() -> Result<()> {
     info!("Tree checks passed, testing restored accounts can transact");
 
     // Test that restored accounts can send transactions
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: private_mention(to_account_id1),
-        to: Some(private_mention(to_account_id2)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 10,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
-
-    let command = Command::AuthTransfer(AuthTransferSubcommand::Send {
-        from: public_mention(to_account_id3),
-        to: Some(public_mention(to_account_id4)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: 11,
-    });
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    send(
+        &mut ctx,
+        private_mention(to_account_id1),
+        private_mention(to_account_id2),
+        10,
+    )
+    .await?;
+    send(
+        &mut ctx,
+        public_mention(to_account_id3),
+        public_mention(to_account_id4),
+        11,
+    )
+    .await?;
 
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 

--- a/integration_tests/tests/pinata.rs
+++ b/integration_tests/tests/pinata.rs
@@ -6,13 +6,13 @@
 
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::Result;
+use common::PINATA_BASE58;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
-    verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance,
+    assert_private_commitment_in_state, private_mention, public_mention, sync_private,
 };
 use log::info;
-use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
 use wallet::cli::{
     Command, SubcommandReturnValue,
@@ -41,10 +41,7 @@ async fn claim_pinata_to_uninitialized_public_account_fails_fast() -> Result<()>
         anyhow::bail!("Expected RegisterAccount return value");
     };
 
-    let pinata_balance_pre = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     let claim_result = wallet::cli::execute_subcommand(
         ctx.wallet_mut(),
@@ -64,10 +61,7 @@ async fn claim_pinata_to_uninitialized_public_account_fails_fast() -> Result<()>
         "Expected init guidance, got: {err}",
     );
 
-    let pinata_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre);
 
@@ -93,10 +87,7 @@ async fn claim_pinata_to_uninitialized_private_account_fails_fast() -> Result<()
         anyhow::bail!("Expected RegisterAccount return value");
     };
 
-    let pinata_balance_pre = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     let claim_result = wallet::cli::execute_subcommand(
         ctx.wallet_mut(),
@@ -116,10 +107,7 @@ async fn claim_pinata_to_uninitialized_private_account_fails_fast() -> Result<()
         "Expected init guidance, got: {err}",
     );
 
-    let pinata_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre);
 
@@ -135,10 +123,7 @@ async fn claim_pinata_to_existing_public_account() -> Result<()> {
         to: public_mention(ctx.existing_public_accounts()[0]),
     });
 
-    let pinata_balance_pre = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
@@ -146,15 +131,9 @@ async fn claim_pinata_to_existing_public_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let pinata_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
-    let winner_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(ctx.existing_public_accounts()[0])
-        .await?;
+    let winner_balance_post = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre - pinata_prize);
     assert_eq!(winner_balance_post, 10000 + pinata_prize);
@@ -173,10 +152,7 @@ async fn claim_pinata_to_existing_private_account() -> Result<()> {
         to: private_mention(ctx.existing_private_accounts()[0]),
     });
 
-    let pinata_balance_pre = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
     let SubcommandReturnValue::PrivacyPreservingTransfer { tx_hash: _ } = result else {
@@ -187,19 +163,11 @@ async fn claim_pinata_to_existing_private_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Syncing private accounts");
-    let command = Command::Account(AccountSubcommand::SyncPrivate {});
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(ctx.existing_private_accounts()[0])
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, ctx.existing_private_accounts()[0], "account").await?;
 
-    let pinata_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre - pinata_prize);
 
@@ -239,37 +207,23 @@ async fn claim_pinata_to_new_private_account() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(winner_account_id)
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, winner_account_id, "account").await?;
 
     // Claim pinata to the new private account
     let command = Command::Pinata(PinataProgramAgnosticSubcommand::Claim {
         to: private_mention(winner_account_id),
     });
 
-    let pinata_balance_pre = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let new_commitment = ctx
-        .wallet()
-        .get_private_account_commitment(winner_account_id)
-        .context("Failed to get private account commitment")?;
-    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
+    assert_private_commitment_in_state(&ctx, winner_account_id, "account").await?;
 
-    let pinata_balance_post = ctx
-        .sequencer_client()
-        .get_account_balance(system_accounts::pinata_account_id())
-        .await?;
+    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre - pinata_prize);
 

--- a/integration_tests/tests/pinata.rs
+++ b/integration_tests/tests/pinata.rs
@@ -6,17 +6,15 @@
 
 use std::time::Duration;
 
-use anyhow::Result;
-use common::PINATA_BASE58;
+use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance,
-    assert_private_commitment_in_state, private_mention, public_mention, sync_private,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, account_balance, new_account, private_mention,
+    public_mention, sync_private, verify_commitment_is_in_state,
 };
 use log::info;
 use tokio::test;
 use wallet::cli::{
     Command, SubcommandReturnValue,
-    account::{AccountSubcommand, NewSubcommand},
     programs::{
         native_token_transfer::AuthTransferSubcommand, pinata::PinataProgramAgnosticSubcommand,
     },
@@ -26,22 +24,9 @@ use wallet::cli::{
 async fn claim_pinata_to_uninitialized_public_account_fails_fast() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: winner_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let winner_account_id = new_account(&mut ctx, false, None).await?;
 
-    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_pre = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     let claim_result = wallet::cli::execute_subcommand(
         ctx.wallet_mut(),
@@ -61,7 +46,7 @@ async fn claim_pinata_to_uninitialized_public_account_fails_fast() -> Result<()>
         "Expected init guidance, got: {err}",
     );
 
-    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_post = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre);
 
@@ -72,22 +57,9 @@ async fn claim_pinata_to_uninitialized_public_account_fails_fast() -> Result<()>
 async fn claim_pinata_to_uninitialized_private_account_fails_fast() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: winner_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let winner_account_id = new_account(&mut ctx, true, None).await?;
 
-    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_pre = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     let claim_result = wallet::cli::execute_subcommand(
         ctx.wallet_mut(),
@@ -107,7 +79,7 @@ async fn claim_pinata_to_uninitialized_private_account_fails_fast() -> Result<()
         "Expected init guidance, got: {err}",
     );
 
-    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_post = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre);
 
@@ -123,7 +95,7 @@ async fn claim_pinata_to_existing_public_account() -> Result<()> {
         to: public_mention(ctx.existing_public_accounts()[0]),
     });
 
-    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_pre = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
@@ -131,7 +103,7 @@ async fn claim_pinata_to_existing_public_account() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     info!("Checking correct balance move");
-    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_post = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     let winner_balance_post = account_balance(&ctx, ctx.existing_public_accounts()[0]).await?;
 
@@ -152,7 +124,7 @@ async fn claim_pinata_to_existing_private_account() -> Result<()> {
         to: private_mention(ctx.existing_private_accounts()[0]),
     });
 
-    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_pre = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     let result = wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
     let SubcommandReturnValue::PrivacyPreservingTransfer { tx_hash: _ } = result else {
@@ -165,9 +137,13 @@ async fn claim_pinata_to_existing_private_account() -> Result<()> {
     info!("Syncing private accounts");
     sync_private(&mut ctx).await?;
 
-    assert_private_commitment_in_state(&ctx, ctx.existing_private_accounts()[0], "account").await?;
+    let new_commitment = ctx
+        .wallet()
+        .get_private_account_commitment(ctx.existing_private_accounts()[0])
+        .context("Failed to get private account commitment")?;
+    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
 
-    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_post = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre - pinata_prize);
 
@@ -183,20 +159,7 @@ async fn claim_pinata_to_new_private_account() -> Result<()> {
     let pinata_prize = 150;
 
     // Create new private account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: winner_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let winner_account_id = new_account(&mut ctx, true, None).await?;
 
     // Initialize account under auth transfer program
     let command = Command::AuthTransfer(AuthTransferSubcommand::Init {
@@ -207,23 +170,31 @@ async fn claim_pinata_to_new_private_account() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    assert_private_commitment_in_state(&ctx, winner_account_id, "account").await?;
+    let new_commitment = ctx
+        .wallet()
+        .get_private_account_commitment(winner_account_id)
+        .context("Failed to get private account commitment")?;
+    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
 
     // Claim pinata to the new private account
     let command = Command::Pinata(PinataProgramAgnosticSubcommand::Claim {
         to: private_mention(winner_account_id),
     });
 
-    let pinata_balance_pre = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_pre = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
 
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    assert_private_commitment_in_state(&ctx, winner_account_id, "account").await?;
+    let new_commitment = ctx
+        .wallet()
+        .get_private_account_commitment(winner_account_id)
+        .context("Failed to get private account commitment")?;
+    assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
 
-    let pinata_balance_post = account_balance(&ctx, PINATA_BASE58.parse().unwrap()).await?;
+    let pinata_balance_post = account_balance(&ctx, system_accounts::pinata_account_id()).await?;
 
     assert_eq!(pinata_balance_post, pinata_balance_pre - pinata_prize);
 

--- a/integration_tests/tests/private_pda.rs
+++ b/integration_tests/tests/private_pda.rs
@@ -9,8 +9,7 @@ use anyhow::{Context as _, Result};
 use authenticated_transfer_core::Instruction as AuthTransferInstruction;
 use common::transaction::LeeTransaction;
 use integration_tests::{
-    LEE_PROGRAM_FOR_TEST_PDA_SPEND_PROXY, TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext,
-    assert_private_commitment_in_state, sync_private, verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, sync_private, verify_commitment_is_in_state,
 };
 use key_protocol::key_management::ephemeral_key_holder::EphemeralKeyHolder;
 use lee::{
@@ -311,8 +310,23 @@ async fn private_pda_family_members_receive_and_spend() -> Result<()> {
     assert_eq!(pda_1_spent.balance, amount - amount_spend_1);
 
     // Post-spend commitments must be in state.
-    assert_private_commitment_in_state(&ctx, alice_pda_0_id, "alice_pda_0").await?;
-    assert_private_commitment_in_state(&ctx, alice_pda_1_id, "alice_pda_1").await?;
+    let post_spend_commitment_0 = ctx
+        .wallet()
+        .get_private_account_commitment(alice_pda_0_id)
+        .context("post-spend commitment for alice_pda_0 missing")?;
+    assert!(
+        verify_commitment_is_in_state(post_spend_commitment_0, ctx.sequencer_client()).await,
+        "alice_pda_0 post-spend commitment not in state"
+    );
+
+    let post_spend_commitment_1 = ctx
+        .wallet()
+        .get_private_account_commitment(alice_pda_1_id)
+        .context("post-spend commitment for alice_pda_1 missing")?;
+    assert!(
+        verify_commitment_is_in_state(post_spend_commitment_1, ctx.sequencer_client()).await,
+        "alice_pda_1 post-spend commitment not in state"
+    );
 
     info!("Private PDA family member receive-and-spend test passed");
     Ok(())

--- a/integration_tests/tests/private_pda.rs
+++ b/integration_tests/tests/private_pda.rs
@@ -9,7 +9,8 @@ use anyhow::{Context as _, Result};
 use authenticated_transfer_core::Instruction as AuthTransferInstruction;
 use common::transaction::LeeTransaction;
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, verify_commitment_is_in_state,
+    LEE_PROGRAM_FOR_TEST_PDA_SPEND_PROXY, TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext,
+    assert_private_commitment_in_state, sync_private, verify_commitment_is_in_state,
 };
 use key_protocol::key_management::ephemeral_key_holder::EphemeralKeyHolder;
 use lee::{
@@ -30,10 +31,7 @@ use lee_core::{
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
-use wallet::{
-    AccountIdentity, WalletCore,
-    cli::{Command, account::AccountSubcommand},
-};
+use wallet::{AccountIdentity, WalletCore};
 
 /// Funds a private PDA by calling `auth_transfer` directly.
 #[expect(
@@ -218,11 +216,7 @@ async fn private_pda_family_members_receive_and_spend() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Sync so alice's wallet discovers and stores both PDAs.
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::SyncPrivate {}),
-    )
-    .await?;
+    sync_private(&mut ctx).await?;
 
     // Both PDAs must be discoverable and have the correct balance.
     let pda_0_account = ctx
@@ -301,11 +295,7 @@ async fn private_pda_family_members_receive_and_spend() -> Result<()> {
     info!("Waiting for block");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::SyncPrivate {}),
-    )
-    .await?;
+    sync_private(&mut ctx).await?;
 
     // After spending, PDAs should have the remaining balance.
     let pda_0_spent = ctx
@@ -321,23 +311,8 @@ async fn private_pda_family_members_receive_and_spend() -> Result<()> {
     assert_eq!(pda_1_spent.balance, amount - amount_spend_1);
 
     // Post-spend commitments must be in state.
-    let post_spend_commitment_0 = ctx
-        .wallet()
-        .get_private_account_commitment(alice_pda_0_id)
-        .context("post-spend commitment for alice_pda_0 missing")?;
-    assert!(
-        verify_commitment_is_in_state(post_spend_commitment_0, ctx.sequencer_client()).await,
-        "alice_pda_0 post-spend commitment not in state"
-    );
-
-    let post_spend_commitment_1 = ctx
-        .wallet()
-        .get_private_account_commitment(alice_pda_1_id)
-        .context("post-spend commitment for alice_pda_1 missing")?;
-    assert!(
-        verify_commitment_is_in_state(post_spend_commitment_1, ctx.sequencer_client()).await,
-        "alice_pda_1 post-spend commitment not in state"
-    );
+    assert_private_commitment_in_state(&ctx, alice_pda_0_id, "alice_pda_0").await?;
+    assert_private_commitment_in_state(&ctx, alice_pda_1_id, "alice_pda_1").await?;
 
     info!("Private PDA family member receive-and-spend test passed");
     Ok(())

--- a/integration_tests/tests/program_deployment.rs
+++ b/integration_tests/tests/program_deployment.rs
@@ -7,7 +7,10 @@ use std::{io::Write as _, time::Duration};
 
 use anyhow::Result;
 use common::transaction::LeeTransaction;
-use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext};
+use integration_tests::{
+    LEE_PROGRAM_FOR_TEST_DATA_CHANGER, TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, get_account,
+};
+use lee::program::Program;
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
@@ -66,7 +69,7 @@ async fn deploy_and_execute_program() -> Result<()> {
     // block
     tokio::time::sleep(Duration::from_secs(2 * TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let post_state_account = ctx.sequencer_client().get_account(account_id).await?;
+    let post_state_account = get_account(&ctx, account_id).await?;
 
     let expected_data: &[u8] = &[];
     assert_eq!(post_state_account.program_owner, claimer.id());

--- a/integration_tests/tests/program_deployment.rs
+++ b/integration_tests/tests/program_deployment.rs
@@ -7,17 +7,11 @@ use std::{io::Write as _, time::Duration};
 
 use anyhow::Result;
 use common::transaction::LeeTransaction;
-use integration_tests::{
-    LEE_PROGRAM_FOR_TEST_DATA_CHANGER, TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, get_account,
-};
-use lee::program::Program;
+use integration_tests::{TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, get_account, new_account};
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
 use tokio::test;
-use wallet::cli::{
-    Command, SubcommandReturnValue,
-    account::{AccountSubcommand, NewSubcommand},
-};
+use wallet::cli::Command;
 
 #[test]
 async fn deploy_and_execute_program() -> Result<()> {
@@ -38,17 +32,7 @@ async fn deploy_and_execute_program() -> Result<()> {
     info!("Waiting for next block creation");
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
-    let SubcommandReturnValue::RegisterAccount { account_id } = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?
-    else {
-        panic!("Expected RegisterAccount return value");
-    };
+    let account_id = new_account(&mut ctx, false, None).await?;
 
     let nonces = ctx.wallet().get_accounts_nonces(vec![account_id]).await?;
     let private_key = ctx

--- a/integration_tests/tests/shared_accounts.rs
+++ b/integration_tests/tests/shared_accounts.rs
@@ -19,7 +19,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention, sync_private,
 };
 use log::info;
 use tokio::test;
@@ -197,8 +197,7 @@ async fn fund_shared_account_from_public() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Sync private accounts
-    let command = Command::Account(AccountSubcommand::SyncPrivate);
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
     // Fund from a public account
     let from_public = ctx.existing_public_accounts()[0];
@@ -216,8 +215,7 @@ async fn fund_shared_account_from_public() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Sync private accounts
-    let command = Command::Account(AccountSubcommand::SyncPrivate);
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
     // Verify the shared account was updated
     let entry = ctx

--- a/integration_tests/tests/token.rs
+++ b/integration_tests/tests/token.rs
@@ -8,12 +8,11 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, private_mention, public_mention,
-    verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, create_token, get_account, new_account,
+    private_mention, public_mention, token_send, verify_commitment_is_in_state,
 };
 use key_protocol::key_management::key_tree::chain_index::ChainIndex;
 use log::info;
-use sequencer_service_rpc::RpcClient as _;
 use token_core::{TokenDefinition, TokenHolding};
 use tokio::test;
 use wallet::{
@@ -41,22 +40,17 @@ async fn create_and_transfer_public_token() -> Result<()> {
     // Create new token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id),
-        supply_account_id: public_mention(supply_account_id),
-        name: name.clone(),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        name.clone(),
         total_supply,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Check the status of the token definition account
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(definition_acc.program_owner, programs::token().id());
@@ -70,10 +64,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
     );
 
     // Check the status of the token holding account with the total supply
-    let supply_acc = ctx
-        .sequencer_client()
-        .get_account(supply_account_id)
-        .await?;
+    let supply_acc = get_account(&ctx, supply_account_id).await?;
 
     // The account must be owned by the token program
     assert_eq!(supply_acc.program_owner, programs::token().id());
@@ -88,27 +79,17 @@ async fn create_and_transfer_public_token() -> Result<()> {
 
     // Transfer 7 tokens from supply_acc to recipient_account_id
     let transfer_amount = 7;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id),
-        to: Some(public_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id),
+        public_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
     // Check the status of the supply account after transfer
-    let supply_acc = ctx
-        .sequencer_client()
-        .get_account(supply_account_id)
-        .await?;
-    assert_eq!(supply_acc.program_owner, programs::token().id());
+    let supply_acc = get_account(&ctx, supply_account_id).await?;
+    assert_eq!(supply_acc.program_owner, Program::token().id());
     let token_holding = TokenHolding::try_from(&supply_acc.data)?;
     assert_eq!(
         token_holding,
@@ -119,11 +100,8 @@ async fn create_and_transfer_public_token() -> Result<()> {
     );
 
     // Check the status of the recipient account after transfer
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id)
-        .await?;
-    assert_eq!(recipient_acc.program_owner, programs::token().id());
+    let recipient_acc = get_account(&ctx, recipient_account_id).await?;
+    assert_eq!(recipient_acc.program_owner, Program::token().id());
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
     assert_eq!(
         token_holding,
@@ -147,10 +125,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the status of the token definition account after burn
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(
@@ -163,10 +138,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
     );
 
     // Check the status of the recipient account after burn
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id)
-        .await?;
+    let recipient_acc = get_account(&ctx, recipient_account_id).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
 
     assert_eq!(
@@ -195,10 +167,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the status of the token definition account after mint
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(
@@ -211,10 +180,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
     );
 
     // Check the status of the recipient account after mint
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id)
-        .await?;
+    let recipient_acc = get_account(&ctx, recipient_account_id).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
 
     assert_eq!(
@@ -246,23 +212,17 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
     // Create new token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id),
-        supply_account_id: private_mention(supply_account_id),
-        name: name.clone(),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        private_mention(supply_account_id),
+        name.clone(),
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Check the status of the token definition account
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(definition_acc.program_owner, programs::token().id());
@@ -283,20 +243,13 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
 
     // Transfer 7 tokens from supply_acc to recipient_account_id
     let transfer_amount = 7;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: private_mention(supply_account_id),
-        to: Some(private_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        private_mention(supply_account_id),
+        private_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
     let new_commitment1 = ctx
         .wallet()
@@ -324,10 +277,7 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the token definition account after burn
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(
@@ -378,17 +328,14 @@ async fn create_token_with_private_definition() -> Result<()> {
     // Create token with private definition
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: private_mention(definition_account_id),
-        supply_account_id: public_mention(supply_account_id),
-        name: name.clone(),
+    create_token(
+        &mut ctx,
+        private_mention(definition_account_id),
+        public_mention(supply_account_id),
+        name.clone(),
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Verify private definition commitment
     let new_commitment = ctx
@@ -398,10 +345,7 @@ async fn create_token_with_private_definition() -> Result<()> {
     assert!(verify_commitment_is_in_state(new_commitment, ctx.sequencer_client()).await);
 
     // Verify supply account
-    let supply_acc = ctx
-        .sequencer_client()
-        .get_account(supply_account_id)
-        .await?;
+    let supply_acc = get_account(&ctx, supply_account_id).await?;
 
     assert_eq!(supply_acc.program_owner, programs::token().id());
     let token_holding = TokenHolding::try_from(&supply_acc.data)?;
@@ -453,10 +397,7 @@ async fn create_token_with_private_definition() -> Result<()> {
     );
 
     // Verify public recipient received tokens
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id_public)
-        .await?;
+    let recipient_acc = get_account(&ctx, recipient_account_id_public).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
 
     assert_eq!(
@@ -524,17 +465,14 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
     // Create token with both private definition and supply
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: private_mention(definition_account_id),
-        supply_account_id: private_mention(supply_account_id),
+    create_token(
+        &mut ctx,
+        private_mention(definition_account_id),
+        private_mention(supply_account_id),
         name,
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Verify definition commitment
     let definition_commitment = ctx
@@ -570,20 +508,13 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
 
     // Transfer tokens
     let transfer_amount = 7;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: private_mention(supply_account_id),
-        to: Some(private_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        private_mention(supply_account_id),
+        private_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
     // Verify both commitments updated
     let supply_commitment = ctx
@@ -646,40 +577,27 @@ async fn shielded_token_transfer() -> Result<()> {
     // Create token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id),
-        supply_account_id: public_mention(supply_account_id),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
         name,
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Perform shielded transfer: public supply -> private recipient
     let transfer_amount = 7;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: public_mention(supply_account_id),
-        to: Some(private_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        public_mention(supply_account_id),
+        private_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
     // Verify supply account balance
-    let supply_acc = ctx
-        .sequencer_client()
-        .get_account(supply_account_id)
-        .await?;
+    let supply_acc = get_account(&ctx, supply_account_id).await?;
     let token_holding = TokenHolding::try_from(&supply_acc.data)?;
     assert_eq!(
         token_holding,
@@ -731,34 +649,24 @@ async fn deshielded_token_transfer() -> Result<()> {
     // Create token with private supply
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id),
-        supply_account_id: private_mention(supply_account_id),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        private_mention(supply_account_id),
         name,
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Perform deshielded transfer: private supply -> public recipient
     let transfer_amount = 7;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: private_mention(supply_account_id),
-        to: Some(public_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    token_send(
+        &mut ctx,
+        private_mention(supply_account_id),
+        public_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
     // Verify supply account commitment exists
     let new_commitment = ctx
@@ -782,10 +690,7 @@ async fn deshielded_token_transfer() -> Result<()> {
     );
 
     // Verify recipient balance
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id)
-        .await?;
+    let recipient_acc = get_account(&ctx, recipient_account_id).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
     assert_eq!(
         token_holding,
@@ -813,17 +718,14 @@ async fn token_claiming_path_with_private_accounts() -> Result<()> {
     // Create token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: private_mention(definition_account_id),
-        supply_account_id: private_mention(supply_account_id),
+    create_token(
+        &mut ctx,
+        private_mention(definition_account_id),
+        private_mention(supply_account_id),
         name,
         total_supply,
-    };
-
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Create new private account for claiming path
     let recipient_account_id = new_account(&mut ctx, true, None).await?;
@@ -927,21 +829,16 @@ async fn create_token_using_labels() -> Result<()> {
     // Create token using account labels instead of IDs
     let name = "LABELED TOKEN".to_owned();
     let total_supply = 100;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: def_label.into(),
-        supply_account_id: supply_label.into(),
-        name: name.clone(),
+    create_token(
+        &mut ctx,
+        def_label.into(),
+        supply_label.into(),
+        name.clone(),
         total_supply,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+    )
+    .await?;
 
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
-
-    let definition_acc = ctx
-        .sequencer_client()
-        .get_account(definition_account_id)
-        .await?;
+    let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
 
     assert_eq!(definition_acc.program_owner, programs::token().id());
@@ -954,10 +851,7 @@ async fn create_token_using_labels() -> Result<()> {
         }
     );
 
-    let supply_acc = ctx
-        .sequencer_client()
-        .get_account(supply_account_id)
-        .await?;
+    let supply_acc = get_account(&ctx, supply_account_id).await?;
     let token_holding = TokenHolding::try_from(&supply_acc.data)?;
     assert_eq!(
         token_holding,
@@ -1001,37 +895,26 @@ async fn transfer_token_using_from_label() -> Result<()> {
 
     // Create token
     let total_supply = 50;
-    let subcommand = TokenProgramAgnosticSubcommand::New {
-        definition_account_id: public_mention(definition_account_id),
-        supply_account_id: public_mention(supply_account_id),
-        name: "LABEL TEST TOKEN".to_owned(),
+    create_token(
+        &mut ctx,
+        public_mention(definition_account_id),
+        public_mention(supply_account_id),
+        "LABEL TEST TOKEN".to_owned(),
         total_supply,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
-
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+    )
+    .await?;
 
     // Transfer token using from_label instead of from
     let transfer_amount = 20;
-    let subcommand = TokenProgramAgnosticSubcommand::Send {
-        from: supply_label.into(),
-        to: Some(public_mention(recipient_account_id)),
-        to_npk: None,
-        to_vpk: None,
-        to_keys: None,
-        to_identifier: Some(0),
-        amount: transfer_amount,
-    };
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+    token_send(
+        &mut ctx,
+        supply_label.into(),
+        public_mention(recipient_account_id),
+        transfer_amount,
+    )
+    .await?;
 
-    info!("Waiting for next block creation");
-    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
-
-    let recipient_acc = ctx
-        .sequencer_client()
-        .get_account(recipient_account_id)
-        .await?;
+    let recipient_acc = get_account(&ctx, recipient_account_id).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
     assert_eq!(
         token_holding,

--- a/integration_tests/tests/token.rs
+++ b/integration_tests/tests/token.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, create_token, get_account, new_account,
-    private_mention, public_mention, token_send, verify_commitment_is_in_state,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, get_account, new_account, private_mention,
+    public_mention, sync_private, verify_commitment_is_in_state,
 };
 use key_protocol::key_management::key_tree::chain_index::ChainIndex;
 use log::info;
@@ -40,14 +40,16 @@ async fn create_and_transfer_public_token() -> Result<()> {
     // Create new token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        public_mention(definition_account_id),
-        public_mention(supply_account_id),
-        name.clone(),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: public_mention(definition_account_id),
+        supply_account_id: public_mention(supply_account_id),
+        name: name.clone(),
         total_supply,
-    )
-    .await?;
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the status of the token definition account
     let definition_acc = get_account(&ctx, definition_account_id).await?;
@@ -79,17 +81,24 @@ async fn create_and_transfer_public_token() -> Result<()> {
 
     // Transfer 7 tokens from supply_acc to recipient_account_id
     let transfer_amount = 7;
-    token_send(
-        &mut ctx,
-        public_mention(supply_account_id),
-        public_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: public_mention(supply_account_id),
+        to: Some(public_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the status of the supply account after transfer
     let supply_acc = get_account(&ctx, supply_account_id).await?;
-    assert_eq!(supply_acc.program_owner, Program::token().id());
+    assert_eq!(supply_acc.program_owner, programs::token().id());
     let token_holding = TokenHolding::try_from(&supply_acc.data)?;
     assert_eq!(
         token_holding,
@@ -101,7 +110,7 @@ async fn create_and_transfer_public_token() -> Result<()> {
 
     // Check the status of the recipient account after transfer
     let recipient_acc = get_account(&ctx, recipient_account_id).await?;
-    assert_eq!(recipient_acc.program_owner, Program::token().id());
+    assert_eq!(recipient_acc.program_owner, programs::token().id());
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;
     assert_eq!(
         token_holding,
@@ -212,14 +221,17 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
     // Create new token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        public_mention(definition_account_id),
-        private_mention(supply_account_id),
-        name.clone(),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: public_mention(definition_account_id),
+        supply_account_id: private_mention(supply_account_id),
+        name: name.clone(),
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Check the status of the token definition account
     let definition_acc = get_account(&ctx, definition_account_id).await?;
@@ -243,13 +255,20 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
 
     // Transfer 7 tokens from supply_acc to recipient_account_id
     let transfer_amount = 7;
-    token_send(
-        &mut ctx,
-        private_mention(supply_account_id),
-        private_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: private_mention(supply_account_id),
+        to: Some(private_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     let new_commitment1 = ctx
         .wallet()
@@ -328,14 +347,17 @@ async fn create_token_with_private_definition() -> Result<()> {
     // Create token with private definition
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        private_mention(definition_account_id),
-        public_mention(supply_account_id),
-        name.clone(),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: private_mention(definition_account_id),
+        supply_account_id: public_mention(supply_account_id),
+        name: name.clone(),
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify private definition commitment
     let new_commitment = ctx
@@ -465,14 +487,17 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
     // Create token with both private definition and supply
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        private_mention(definition_account_id),
-        private_mention(supply_account_id),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: private_mention(definition_account_id),
+        supply_account_id: private_mention(supply_account_id),
         name,
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify definition commitment
     let definition_commitment = ctx
@@ -508,13 +533,20 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
 
     // Transfer tokens
     let transfer_amount = 7;
-    token_send(
-        &mut ctx,
-        private_mention(supply_account_id),
-        private_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: private_mention(supply_account_id),
+        to: Some(private_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify both commitments updated
     let supply_commitment = ctx
@@ -577,24 +609,34 @@ async fn shielded_token_transfer() -> Result<()> {
     // Create token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        public_mention(definition_account_id),
-        public_mention(supply_account_id),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: public_mention(definition_account_id),
+        supply_account_id: public_mention(supply_account_id),
         name,
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Perform shielded transfer: public supply -> private recipient
     let transfer_amount = 7;
-    token_send(
-        &mut ctx,
-        public_mention(supply_account_id),
-        private_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: public_mention(supply_account_id),
+        to: Some(private_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify supply account balance
     let supply_acc = get_account(&ctx, supply_account_id).await?;
@@ -649,24 +691,34 @@ async fn deshielded_token_transfer() -> Result<()> {
     // Create token with private supply
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        public_mention(definition_account_id),
-        private_mention(supply_account_id),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: public_mention(definition_account_id),
+        supply_account_id: private_mention(supply_account_id),
         name,
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Perform deshielded transfer: private supply -> public recipient
     let transfer_amount = 7;
-    token_send(
-        &mut ctx,
-        private_mention(supply_account_id),
-        public_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: private_mention(supply_account_id),
+        to: Some(public_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Verify supply account commitment exists
     let new_commitment = ctx
@@ -718,14 +770,17 @@ async fn token_claiming_path_with_private_accounts() -> Result<()> {
     // Create token
     let name = "A NAME".to_owned();
     let total_supply = 37;
-    create_token(
-        &mut ctx,
-        private_mention(definition_account_id),
-        private_mention(supply_account_id),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: private_mention(definition_account_id),
+        supply_account_id: private_mention(supply_account_id),
         name,
         total_supply,
-    )
-    .await?;
+    };
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Create new private account for claiming path
     let recipient_account_id = new_account(&mut ctx, true, None).await?;
@@ -759,8 +814,7 @@ async fn token_claiming_path_with_private_accounts() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Sync to claim the account
-    let command = Command::Account(AccountSubcommand::SyncPrivate {});
-    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+    sync_private(&mut ctx).await?;
 
     // Verify commitment exists
     let recipient_commitment = ctx
@@ -829,14 +883,16 @@ async fn create_token_using_labels() -> Result<()> {
     // Create token using account labels instead of IDs
     let name = "LABELED TOKEN".to_owned();
     let total_supply = 100;
-    create_token(
-        &mut ctx,
-        def_label.into(),
-        supply_label.into(),
-        name.clone(),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: def_label.into(),
+        supply_account_id: supply_label.into(),
+        name: name.clone(),
         total_supply,
-    )
-    .await?;
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     let definition_acc = get_account(&ctx, definition_account_id).await?;
     let token_definition = TokenDefinition::try_from(&definition_acc.data)?;
@@ -895,24 +951,32 @@ async fn transfer_token_using_from_label() -> Result<()> {
 
     // Create token
     let total_supply = 50;
-    create_token(
-        &mut ctx,
-        public_mention(definition_account_id),
-        public_mention(supply_account_id),
-        "LABEL TEST TOKEN".to_owned(),
+    let subcommand = TokenProgramAgnosticSubcommand::New {
+        definition_account_id: public_mention(definition_account_id),
+        supply_account_id: public_mention(supply_account_id),
+        name: "LABEL TEST TOKEN".to_owned(),
         total_supply,
-    )
-    .await?;
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Transfer token using from_label instead of from
     let transfer_amount = 20;
-    token_send(
-        &mut ctx,
-        supply_label.into(),
-        public_mention(recipient_account_id),
-        transfer_amount,
-    )
-    .await?;
+    let subcommand = TokenProgramAgnosticSubcommand::Send {
+        from: supply_label.into(),
+        to: Some(public_mention(recipient_account_id)),
+        to_npk: None,
+        to_vpk: None,
+        to_keys: None,
+        to_identifier: Some(0),
+        amount: transfer_amount,
+    };
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), Command::Token(subcommand)).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     let recipient_acc = get_account(&ctx, recipient_account_id).await?;
     let token_holding = TokenHolding::try_from(&recipient_acc.data)?;

--- a/integration_tests/tests/token.rs
+++ b/integration_tests/tests/token.rs
@@ -8,7 +8,7 @@ use std::time::Duration;
 
 use anyhow::{Context as _, Result};
 use integration_tests::{
-    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
+    TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, new_account, private_mention, public_mention,
     verify_commitment_is_in_state,
 };
 use key_protocol::key_management::key_tree::chain_index::ChainIndex;
@@ -30,52 +30,13 @@ async fn create_and_transfer_public_token() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create new account for the token definition
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create new account for the token supply holder
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create new account for receiving a token transaction
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create new token
     let name = "A NAME".to_owned();
@@ -274,52 +235,13 @@ async fn create_and_transfer_token_with_private_supply() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create new account for the token definition (public)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create new account for the token supply holder (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create new account for receiving a token transaction (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create new token
     let name = "A NAME".to_owned();
@@ -448,36 +370,10 @@ async fn create_token_with_private_definition() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token definition account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: Some(ChainIndex::root()),
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, true, Some(ChainIndex::root())).await?;
 
     // Create supply account (public)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: Some(ChainIndex::root()),
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, false, Some(ChainIndex::root())).await?;
 
     // Create token with private definition
     let name = "A NAME".to_owned();
@@ -518,36 +414,10 @@ async fn create_token_with_private_definition() -> Result<()> {
     );
 
     // Create private recipient account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id_private,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id_private = new_account(&mut ctx, true, None).await?;
 
     // Create public recipient account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id_public,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id_public = new_account(&mut ctx, false, None).await?;
 
     // Mint to public account
     let mint_amount_public = 10;
@@ -646,36 +516,10 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token definition account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create supply account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create token with both private definition and supply
     let name = "A NAME".to_owned();
@@ -722,20 +566,7 @@ async fn create_token_with_private_definition_and_supply() -> Result<()> {
     );
 
     // Create recipient account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, true, None).await?;
 
     // Transfer tokens
     let transfer_amount = 7;
@@ -804,52 +635,13 @@ async fn shielded_token_transfer() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token definition account (public)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create supply account (public)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create recipient account (private) for shielded transfer
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create token
     let name = "A NAME".to_owned();
@@ -928,52 +720,13 @@ async fn deshielded_token_transfer() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token definition account (public)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create supply account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create recipient account (public) for deshielded transfer
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create token with private supply
     let name = "A NAME".to_owned();
@@ -1052,36 +805,10 @@ async fn token_claiming_path_with_private_accounts() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create token definition account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create supply account (private)
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: supply_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let supply_account_id = new_account(&mut ctx, true, None).await?;
 
     // Create token
     let name = "A NAME".to_owned();
@@ -1099,20 +826,7 @@ async fn token_claiming_path_with_private_accounts() -> Result<()> {
     tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
 
     // Create new private account for claiming path
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Private {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, true, None).await?;
 
     // Get keys for foreign mint (claiming path)
     let holder = ctx
@@ -1263,20 +977,7 @@ async fn transfer_token_using_from_label() -> Result<()> {
     let mut ctx = TestContext::new().await?;
 
     // Create definition account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: definition_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let definition_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create supply account with a label
     let supply_label = Label::new("token-supply-sender");
@@ -1296,20 +997,7 @@ async fn transfer_token_using_from_label() -> Result<()> {
     };
 
     // Create recipient account
-    let result = wallet::cli::execute_subcommand(
-        ctx.wallet_mut(),
-        Command::Account(AccountSubcommand::New(NewSubcommand::Public {
-            cci: None,
-            label: None,
-        })),
-    )
-    .await?;
-    let SubcommandReturnValue::RegisterAccount {
-        account_id: recipient_account_id,
-    } = result
-    else {
-        anyhow::bail!("Expected RegisterAccount return value");
-    };
+    let recipient_account_id = new_account(&mut ctx, false, None).await?;
 
     // Create token
     let total_supply = 50;


### PR DESCRIPTION
## 🎯 Purpose

This PR introduces helper functions to reduce duplicated code in `integration_tests`. This refactor aims to shorten long functions in `integration_tests`.

## ⚙️ Approach

Simple refactor.

## 🧪 How to Test

No change in functionality. All previous tests should pass.

## 🔗 Dependencies

N/A

## 🔜 Future Work

N/A

## 📋 PR Completion Checklist

- [X] Complete PR description
- [X] Implement the core functionality
- [X] Add/update tests
- [X] Add/update documentation and inline comments
