### PR TITLE
fix:  address issue 513

### DIFF
--- a/lee/state_machine/src/public_transaction/transaction.rs
+++ b/lee/state_machine/src/public_transaction/transaction.rs
@@ -243,6 +243,21 @@ pub mod tests {
     }
 
     #[test]
+    fn empty_transaction_is_rejected() {
+        let state = state_for_tests();
+        let message = Message::new_preserialized(
+            Program::authenticated_transfer_program().id(),
+            vec![],
+            vec![],
+            vec![0; 4],
+        );
+        let witness_set = WitnessSet::from_raw_parts(vec![]);
+        let tx = PublicTransaction::new(message, witness_set);
+        let result = ValidatedStateDiff::from_public_transaction(&tx, &state, 1, 0);
+        assert!(matches!(result, Err(LeeError::InvalidInput(_))));
+    }
+
+    #[test]
     fn program_id_must_belong_to_bulitin_program_ids() {
         let (key1, key2, addr1, addr2) = keys_for_tests();
         let state = state_for_tests();

--- a/lee/state_machine/src/validated_state_diff.rs
+++ b/lee/state_machine/src/validated_state_diff.rs
@@ -49,6 +49,11 @@ impl ValidatedStateDiff {
         let message = tx.message();
         let witness_set = tx.witness_set();
 
+        ensure!(
+            !message.account_ids.is_empty(),
+            LeeError::InvalidInput("Public transaction must have at least one account".into())
+        );
+
         // All account_ids must be different
         ensure!(
             message.account_ids.iter().collect::<HashSet<_>>().len() == message.account_ids.len(),


### PR DESCRIPTION
## 🎯 Purpose

Address [Issue 513](https://github.com/logos-blockchain/logos-execution-zone/issues/513).

## ⚙️ Approach

Prevents DOS attack by introducing a check to ensure at least one public account id is provided to a transaction. Blocking empty `WitnessSet` is would block system programs (e.g., clock program). Thus, address the issue by requiring an account id for public accounts.

- [X] Add criteria
- [X] Add test `empty_transaction_is_rejected`

## 🧪 How to Test

All previous tests work, plus `empty_transaction_is_rejected`.

## 🔗 Dependencies

N/A

## 🔜 Future Work

N/A

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [X] Complete PR description
- [X] Implement the core functionality
- [X] Add/update tests
- [X] Add/update documentation and inline comments
