### PR TITLE
fix(indexer): update config files

### DIFF
--- a/lez/indexer/service/configs/debug/indexer_config.json
+++ b/lez/indexer/service/configs/debug/indexer_config.json
@@ -1,7 +1,7 @@
 {
     "consensus_info_polling_interval": "1s",
     "bedrock_config": {
-        "addr": "http://localhost:8080"
+        "addr": "http://localhost:18080"
     },
     "channel_id": "0101010101010101010101010101010101010101010101010101010101010101"
 }

--- a/lez/indexer/service/configs/docker/indexer_config.json
+++ b/lez/indexer/service/configs/docker/indexer_config.json
@@ -1,8 +1,7 @@
 {
-    "home": ".",
-    "consensus_info_polling_interval": "1s",
-    "bedrock_config": {
-        "addr": "http://host.docker.internal:8080"
-    },
-    "channel_id": "0101010101010101010101010101010101010101010101010101010101010101"
+  "consensus_info_polling_interval": "1s",
+  "bedrock_config": {
+    "addr": "http://host.docker.internal:18080"
+  },
+  "channel_id": "0101010101010101010101010101010101010101010101010101010101010101"
 }


### PR DESCRIPTION
A recent Docker fix changed the bedrock node's HTTP API port from `8080` to `18080`, but the indexer's config files were left pointing at the old port. This PR realigns the indexer configs so they connect to bedrock on the correct port.

## ⚙️ Approach

Update the bedrock `addr` in the indexer config files to use port `18080`, and tidy up the docker config in the process.

- [x] Fix `debug/indexer_config.json`: `bedrock_config.addr` `http://localhost:8080` → `http://localhost:18080`
- [x] Fix `docker/indexer_config.json`: `bedrock_config.addr` `http://host.docker.internal:8080` → `http://host.docker.internal:18080`
- [x] Drop the stale `"home": "."` entry from the docker config and normalize its indentation

## 🧪 How to Test

Run bedrock + sequencer + indexer with `just`.

## 🔗 Dependencies

None.

## 🔜 Future Work

None.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments