### PR TITLE
fix(deny): ignore RUSTSEC-2026-0185 (quinn-proto, transitive via libp2p)

### DIFF
--- a/.deny.toml
+++ b/.deny.toml
@@ -18,6 +18,7 @@ ignore = [
 
   { id = "RUSTSEC-2024-0370", reason = "transitive dependency of `logos-blockchain-http-api-common`, can't do anything than wait for upstream fix" },
   { id = "RUSTSEC-2026-0173", reason = "`proc-macro-error2` is unmaintained; pulled in transitively via `leptos_macro` and `overwatch-derive`, waiting on upstream fix" },
+  { id = "RUSTSEC-2026-0185", reason = "`quinn-proto` remote memory exhaustion; pulled in transitively via `logos-blockchain-libp2p`, waiting on upstream fix" },
 ]
 yanked = "deny"
 unused-ignored-advisory = "deny"


### PR DESCRIPTION
## 🎯 Purpose

Unblock the repo-wide `deny` CI failure on RUSTSEC-2026-0185 (`quinn-proto` remote memory exhaustion), pulled in transitively via `logos-blockchain-libp2p`.

## ⚙️ Approach

Add RUSTSEC-2026-0185 to the `[advisories].ignore` list in `.deny.toml`.

- [x] Add RUSTSEC-2026-0185 ignore entry with reason

## 🧪 How to Test

`cargo deny -c .deny.toml check advisories` passes, and the `deny` CI job goes green.

## 🔗 Dependencies

None

## 🔜 Future Work

Drop the ignore once `logos-blockchain-libp2p` ships a `quinn-proto` bump that resolves RUSTSEC-2026-0185.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
