### PR TITLE
fix(lee): use test program in empty tx instead of authenticated tranfer

### DIFF
--- a/lee/state_machine/src/public_transaction/transaction.rs
+++ b/lee/state_machine/src/public_transaction/transaction.rs
@@ -247,7 +247,7 @@ pub mod tests {
     fn empty_transaction_is_rejected() {
         let state = state_for_tests();
         let message = Message::new_preserialized(
-            Program::authenticated_transfer_program().id(),
+            crate::test_methods::simple_balance_transfer().id(),
             vec![],
             vec![],
             vec![0; 4],


### PR DESCRIPTION
## 🎯 Purpose

Fix lee test module

## ⚙️ Approach

Use a test program in `empty_transaction` instead of the authenticated transfer

## 🧪 How to Test

*How to verify that this PR works as intended.*

`RISC0_SKIP_BUILD=1 cargo clippy --workspace --all-targets --all-features -- -D warnings

## 🔜 Future Work

None

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
