### PR TITLE
fix(lez/indexer): initialize testnet with the correct state

### DIFF
--- a/integration_tests/tests/pinata.rs
+++ b/integration_tests/tests/pinata.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use anyhow::{Context as _, Result};
 use integration_tests::{
     TIME_TO_WAIT_FOR_BLOCK_SECONDS, TestContext, private_mention, public_mention,
-    verify_commitment_is_in_state,
+    verify_commitment_is_in_state, wait_for_indexer_to_catch_up,
 };
 use log::info;
 use sequencer_service_rpc::RpcClient as _;
@@ -160,6 +160,41 @@ async fn claim_pinata_to_existing_public_account() -> Result<()> {
     assert_eq!(winner_balance_post, 10000 + pinata_prize);
 
     info!("Successfully claimed pinata to public account");
+
+    Ok(())
+}
+
+#[test]
+async fn claim_pinata_indexer_keeps_up() -> Result<()> {
+    let mut ctx = TestContext::new().await?;
+
+    let command = Command::Pinata(PinataProgramAgnosticSubcommand::Claim {
+        to: public_mention(ctx.existing_public_accounts()[0]),
+    });
+
+    wallet::cli::execute_subcommand(ctx.wallet_mut(), command).await?;
+
+    info!("Waiting for next block creation");
+    tokio::time::sleep(Duration::from_secs(TIME_TO_WAIT_FOR_BLOCK_SECONDS)).await;
+
+    info!("Waiting for indexer to parse blocks");
+    wait_for_indexer_to_catch_up(&ctx).await?;
+
+    let winner_ind_state = indexer_service_rpc::RpcClient::get_account(
+        &**ctx.indexer_client(),
+        ctx.existing_public_accounts()[0].into(),
+    )
+    .await
+    .unwrap();
+    let winner_seq_state = sequencer_service_rpc::RpcClient::get_account(
+        ctx.sequencer_client(),
+        ctx.existing_public_accounts()[0],
+    )
+    .await?;
+
+    assert_eq!(winner_ind_state, winner_seq_state.into());
+
+    info!("Indexer correctly indexed the pinata claim");
 
     Ok(())
 }

--- a/lez/indexer/core/Cargo.toml
+++ b/lez/indexer/core/Cargo.toml
@@ -7,6 +7,10 @@ license = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+default = []
+testnet = []
+
 [dependencies]
 common.workspace = true
 logos-blockchain-zone-sdk.workspace = true

--- a/lez/indexer/core/src/block_store.rs
+++ b/lez/indexer/core/src/block_store.rs
@@ -23,7 +23,12 @@ impl IndexerStore {
     /// Starting database at the start of new chain.
     /// Creates files if necessary.
     pub fn open_db(location: &Path) -> Result<Self> {
+        #[cfg(not(feature = "testnet"))]
         let initial_state = testnet_initial_state::initial_state();
+
+        #[cfg(feature = "testnet")]
+        let initial_state = testnet_initial_state::initial_state_testnet();
+
         let dbio = RocksDBIO::open_or_create(location, &initial_state)?;
 
         let current_state = dbio.final_state()?;

--- a/lez/indexer/ffi/Cargo.toml
+++ b/lez/indexer/ffi/Cargo.toml
@@ -6,7 +6,7 @@ version = "0.1.0"
 
 [dependencies]
 lee.workspace = true
-indexer_core.workspace = true
+indexer_core = { workspace = true, features = ["testnet"] }
 indexer_service_protocol = { workspace = true, features = ["convert"] }
 
 env_logger.workspace = true

--- a/lez/indexer/service/Cargo.toml
+++ b/lez/indexer/service/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 [dependencies]
 indexer_service_protocol = { workspace = true, features = ["convert"] }
 indexer_service_rpc = { workspace = true, features = ["server"] }
-indexer_core.workspace = true
+indexer_core = { workspace = true, features = ["testnet"] }
 
 clap = { workspace = true, features = ["derive"] }
 anyhow.workspace = true


### PR DESCRIPTION
## 🎯 Purpose

Fixes #586. The indexer used a different genesis state than the sequencer. The sequencer's genesis has the pinata program and account, but the indexer's genesis did not. When a block claimed pinata, the indexer failed with "Unknown program" and stopped indexing all blocks after that.

## ⚙️ Approach

Made the indexer build its genesis the same way the sequencer does.

- [x] Add a `testnet` feature to `indexer_core`, same as `sequencer_core` already has
- [x] Use `initial_state_testnet()` instead of `initial_state()` in `IndexerStore::open_db` when the feature is on
- [x] Turn on the `testnet` feature for `indexer_service` and `indexer_ffi` (ffi also builds its own local genesis for the wallet)
- [x] Add a test that claims pinata and checks the indexer stays in sync

## 🧪 How to Test

Run:
```
cargo test -p integration_tests --test pinata claim_pinata_indexer_keeps_up
```

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
