### PR TITLE
feat(lez/wallet): add change-network command

### DIFF
--- a/lez/wallet/src/cli/mod.rs
+++ b/lez/wallet/src/cli/mod.rs
@@ -19,12 +19,14 @@ use crate::{
         config::ConfigSubcommand,
         group::GroupSubcommand,
         keycard::KeycardSubcommand,
+        network::NetworkAlias,
         programs::{
             amm::AmmProgramAgnosticSubcommand, ata::AtaSubcommand, bridge::BridgeSubcommand,
             native_token_transfer::AuthTransferSubcommand, pinata::PinataProgramAgnosticSubcommand,
             token::TokenProgramAgnosticSubcommand, vault::VaultSubcommand,
         },
     },
+    config::SequencerConnectionData,
     storage::Storage,
 };
 
@@ -33,6 +35,7 @@ pub mod chain;
 pub mod config;
 pub mod group;
 pub mod keycard;
+pub mod network;
 pub mod programs;
 
 pub(crate) trait WalletSubcommand {
@@ -80,6 +83,11 @@ pub enum Command {
     /// Command to setup config, get and set config fields.
     #[command(subcommand)]
     Config(ConfigSubcommand),
+    /// Change the network the wallet points to.
+    ChangeNetwork {
+        /// `testnet`, `local`, or a custom sequencer URL.
+        network: NetworkAlias,
+    },
     /// Restoring keys from given password at given `depth`.
     ///
     /// !!!WARNING!!! will rewrite current storage.
@@ -274,6 +282,20 @@ pub async fn execute_subcommand(
         }
         Command::Config(config_subcommand) => {
             config_subcommand.handle_subcommand(wallet_core).await?
+        }
+        Command::ChangeNetwork { network } => {
+            let sequencer_addr: url::Url = network.try_into().context("Invalid sequencer URL")?;
+
+            let mut config = wallet_core.config().clone();
+            config.sequencers = vec![SequencerConnectionData {
+                sequencer_addr,
+                basic_auth: None,
+            }];
+
+            wallet_core.set_config(config);
+            wallet_core.store_config_changes().await?;
+
+            SubcommandReturnValue::Empty
         }
         Command::RestoreKeys { depth } => {
             let mnemonic = read_mnemonic_from_stdin()?;

--- a/lez/wallet/src/cli/network.rs
+++ b/lez/wallet/src/cli/network.rs
@@ -1,0 +1,38 @@
+use std::{convert::Infallible, str::FromStr};
+
+use url::Url;
+
+const TESTNET_SEQUENCER_ADDR: &str = "https://testnet.lez.logos.co";
+const LOCAL_SEQUENCER_ADDR: &str = "http://127.0.0.1:3040";
+
+/// A `change-network` argument: `testnet`, `local`, or a custom sequencer URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NetworkAlias {
+    Testnet,
+    Local,
+    Other(String),
+}
+
+impl FromStr for NetworkAlias {
+    type Err = Infallible;
+
+    fn from_str(network: &str) -> Result<Self, Self::Err> {
+        Ok(match network {
+            "testnet" => Self::Testnet,
+            "local" => Self::Local,
+            other => Self::Other(other.to_owned()),
+        })
+    }
+}
+
+impl TryFrom<NetworkAlias> for Url {
+    type Error = url::ParseError;
+
+    fn try_from(alias: NetworkAlias) -> Result<Self, Self::Error> {
+        match alias {
+            NetworkAlias::Testnet => TESTNET_SEQUENCER_ADDR.parse(),
+            NetworkAlias::Local => LOCAL_SEQUENCER_ADDR.parse(),
+            NetworkAlias::Other(url) => url.parse(),
+        }
+    }
+}

--- a/lez/wallet/src/config.rs
+++ b/lez/wallet/src/config.rs
@@ -77,7 +77,7 @@ impl Default for WalletConfig {
     fn default() -> Self {
         Self {
             sequencers: vec![SequencerConnectionData {
-                sequencer_addr: "http://127.0.0.1:3040".parse().unwrap(),
+                sequencer_addr: "https://testnet.lez.logos.co".parse().unwrap(),
                 basic_auth: None,
             }],
             seq_poll_timeout: Duration::from_secs(12),


### PR DESCRIPTION
## 🎯 Purpose

Adds a way to switch the wallet's network from the CLI.

## ⚙️ Approach

- [x] Add `wallet change-network` command
- [x] Prompt user to pick testnet, local, or custom
- [x] Set sequencer_addr based on the choice
- [x] Make testnet the default network

## 🧪 How to Test

Run `wallet change-network`, pick each option (1, 2, 3), and check the config file has the right `sequencer_addr`.

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
