### PR TITLE
fix(macos): nuke xcrun cache

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,7 @@
             done
             if [ -n "$tool" ]; then
               unset DEVELOPER_DIR SDKROOT
+              export xcrun_nocache=1
             fi
             exec /usr/bin/xcrun "$@"
           '';


### PR DESCRIPTION
## Summary

Otherwise the build in https://github.com/logos-blockchain/lez-programs/pull/210 fails like this 

```
From https://github.com/logos-blockchain/logos-execution-zone
 * branch              a58fbce2ff48c58b7bb5001b1a27e64b9596ee3a -> FETCH_HEAD
error: Cannot build '/nix/store/dcpc3xhsknsvjcn648kz3r3x44zck152-logos-execution-zone-wallet-ffi-deps-0.1.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/k719vfi6l18m2919bsklhpyg42zcvai0-logos-execution-zone-wallet-ffi-deps-0.1.0
       Last 25 log lines:
       >   Could not build metal kernels
       >   note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
       >
       >   thread '<unnamed>' (7784109) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       >
       >   thread '<unnamed>' (7784106) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       >   error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
       >
       >   thread '<unnamed>' (7784110) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       >   error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
       >
       >   thread '<unnamed>' (7784103) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       >   error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
       >
       >   thread '<unnamed>' (7784104) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       >   error: error: cannot execute tool 'metal' due to missing Metal Toolchain; use: xcodebuild -downloadComponent MetalToolchain
       >
       >   thread '<unnamed>' (7784107) panicked at /nix/store/xfqs4fscxb62d8yiyjqbdf156lgwy5d2-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/risc0-build-kernel-2.0.1/src/lib.rs:253:29:
       >   Could not build metal kernels
       > warning: build failed, waiting for other jobs to finish...
       For full logs, run:
         nix-store -l /nix/store/dcpc3xhsknsvjcn648kz3r3x44zck152-logos-execution-zone-wallet-ffi-deps-0.1.0.drv
error: Cannot build '/nix/store/p4wgy9slxxcv66k6ddzsfpj6r9qc29mj-logos-execution-zone-wallet-ffi-0.1.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/a5qq2b1hgsfg6vq5x8wd1sizbr17f385-logos-execution-zone-wallet-ffi-0.1.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/kwkq6mqp6yyxzdmg41yk8r8av29pxidl-logos-logos_execution_zone-module-lib-1.0.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/bgnz009b3sy50rdj0y9nnh75nbny1vn7-logos-logos_execution_zone-module-lib-1.0.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/7jnv5yq7gds0n99cdikql6bdl79xfcb8-logos-logos_execution_zone-module-lib-lgx-1.0.0.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/5zy3cjj465pgnpiq5gcs2995qdfr5hx3-logos-logos_execution_zone-module-lib-lgx-1.0.0
error: Build failed due to failed dependency
error: Cannot build '/nix/store/7svlfvv3rzb0kvl3vwm70dylwrq3b65z-logos-amm_ui-plugin-dir-modules.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/9angxz22yvpvhyrz1x7ggn6hrj02yhl1-logos-amm_ui-plugin-dir-modules
error: Build failed due to failed dependency
error: Cannot build '/nix/store/3n7s08gi842aas0b11kvmyi8aaj7dvw9-run-logos-standalone-ui.drv'.
       Reason: 1 dependency failed.
       Output paths:
         /nix/store/fm2jfvhh1ib3awd7mrr1h944r7ik5wfd-run-logos-standalone-ui
error: Build failed due to failed dependency
```