### PR TITLE
test: Groth16 for proving (not for merging, just testing)

### DIFF
--- a/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
+++ b/lee/state_machine/src/privacy_preserving_transaction/circuit/mod.rs
@@ -132,7 +132,7 @@ pub fn execute_and_prove(
     env_builder.write(&circuit_input).unwrap();
     let env = env_builder.build().unwrap();
     let prover = default_prover();
-    let opts = ProverOpts::succinct();
+    let opts = ProverOpts::groth16();
     let prove_info = prover
         .prove_with_opts(env, PRIVACY_PRESERVING_CIRCUIT_ELF, &opts)
         .map_err(|e| LeeError::CircuitProvingError(e.to_string()))?;


### PR DESCRIPTION
## 🎯 Purpose

This branch enables real Groth16 proofs generated using Risc0. Previous tests with Groth16 proofs resulted in errors on certain systems. Two specific errors were identified resulting in failed tests:
- Insufficient memory
- Non x86 architecture

These directions assume that Docker is installed. We provide two sets of directions (Linux setup and non x86).

### Path 1: x86 / Linux setup

1. If using Docker Desktop, raise Settings → Resources → Memory to 8 GB+. (Docker Engine on
   Linux typically has no cap by default.)
2. Run with the `prove` feature enabled, pointing `RISC0_WORK_DIR` at a persistent directory
   so proving artifacts (`seal.r0`, `input.json`) survive the run:
   ```bash
   RISC0_WORK_DIR=/path/to/work-dir cargo test -p lee --release --features prove \
     prove_privacy_preserving_execution_circuit_public_and_private_pre_accounts -- --nocapture
   ```
   (Substitute your actual Groth16 entrypoint if different.)
3. (Optional, if step 2 failed with exit `137`) Replay the captured artifacts standalone to
   test different memory caps without re-running the full proving step each time:
   ```bash
   docker run --rm --memory=8g \
     -v /path/to/work-dir:/mnt \
     risczero/risc0-groth16-prover:v2025-04-03.1
   ```
   (8 GB is the verified floor — 6 GB and below fails with exit `137`/OOM.)

### Path 2: non-x86 (ARM64 — Apple Silicon, ARM64 Linux)

1. **macOS only:** if using Docker Desktop, enable Settings → General → "Use Rosetta for
   x86/amd64 emulation on Apple Silicon."
2. **Linux only (no Docker Desktop):** register emulation once per host:
   ```bash
   docker run --privileged --rm tonistiigi/binfmt --install all
   ```
3. If using Docker Desktop, raise Settings → Resources → Memory to 12 GB+. (Higher than x86
   to cover emulation overhead; not empirically verified like the 8 GB x86 figure.)
4. Force the amd64 platform and run, pointing `RISC0_WORK_DIR` at a persistent directory so
   proving artifacts survive the run:
   ```bash
   RISC0_WORK_DIR=/path/to/work-dir DOCKER_DEFAULT_PLATFORM=linux/amd64 \
     cargo test -p lee --release --features prove \
     prove_privacy_preserving_execution_circuit_public_and_private_pre_accounts -- --nocapture
   ```
   (Forcing amd64 is required — the image's native arm64 build is unofficial/unsupported
   upstream and fails with exit `125`.)
5. (Optional, if step 4 failed with exit `137`) Replay the captured artifacts standalone to
   test different memory caps:
   ```bash
   docker run --rm --platform=linux/amd64 --memory=12g \
     -v /path/to/work-dir:/mnt \
     risczero/risc0-groth16-prover:v2025-04-03.1
   ```

#### Quick troubleshooting reference

| Exit code | Likely cause |
|---|---|
| `137` | Out of memory — raise `--memory` |
| `125` | Wrong/unsupported platform resolved (ARM64: force `linux/amd64`), or daemon/image issue |


## ⚙️ Approach

*Describe the core changes introduced by this PR.*

TO COMPLETE

- [ ] Change ...
- [ ] Add ...
- [ ] Fix ...
- [ ] ...

## 🧪 How to Test

*How to verify that this PR works as intended.*

TO COMPLETE

## 🔗 Dependencies

*Link PRs that must be merged before this one.*

TO COMPLETE IF APPLICABLE

## 🔜 Future Work

*List any work intentionally left out of this PR, whether due to scope, prioritization, or pending decisions.*

TO COMPLETE IF APPLICABLE

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [ ] Complete PR description
- [ ] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
