### PR TITLE
ci!: valid_proof_test removed from PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,7 @@ jobs:
 
   valid-proof-test:
     needs: ci-image
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:

--- a/lez/common/src/lib.rs
+++ b/lez/common/src/lib.rs
@@ -9,6 +9,7 @@ pub mod config;
 pub mod transaction;
 
 // Module for tests utility functions
+//
 // TODO: Compile only for tests
 pub mod test_utils;
 


### PR DESCRIPTION
## 🎯 Purpose

`valid_proof_test` can be run only on pushes into `main` or `dev`. It is sufficient and saves a lot of tame.

## ⚙️ Approach

- [x] Added push condition to `valid_proof_test`.

## 🧪 How to Test

CI must skip `valid_proof_test` in PR, include on dev.

## 🔗 Dependencies

None

## 🔜 Future Work

None

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [ ] Add/update tests
- [ ] Add/update documentation and inline comments
