### PR TITLE
test(lez/sequencer): reproduce block size vs inscription cap gap

### DIFF
--- a/lez/sequencer/core/src/block_publisher.rs
+++ b/lez/sequencer/core/src/block_publisher.rs
@@ -551,11 +551,14 @@ mod tests {
     /// committed to local storage but `publish_block` can never inscribe it on Bedrock, silently
     /// losing its transactions.
     ///
-    /// Currently fails: the default `max_block_size` (1 MiB) exceeds the base layer's inscription
-    /// cap (`Inscription::MAX` = `MAX_BLOCK_SIZE * 7 / 8` = 917 504 bytes), so any block sized in
-    /// the 917 505..=1 048 576 byte gap passes zone validation but is rejected by the
-    /// `Vec<u8> -> Inscription` conversion in `publish_block`. Deploying several programs in one
-    /// block (e.g. the scaffold's bundled examples) lands in this gap in practice.
+    /// Regression guard: with the base layer's inscription cap at 917 504 bytes
+    /// (`MAX_BLOCK_SIZE * 7 / 8` before logos-blockchain@0dc34e2c raised it), the default
+    /// `max_block_size` (1 MiB) exceeded the cap and any block sized in the gap passed zone
+    /// validation but was rejected by the `Vec<u8> -> Inscription` conversion in `publish_block`
+    /// — e.g. deploying the scaffold's bundled example programs in one block. Nothing ties the
+    /// two limits together, so this test fails if either drifts back out of range. Note the
+    /// inscribed payload is the full signed `Block`, slightly larger than the
+    /// `HashableBlockData` the admission check measures.
     #[test]
     fn max_sized_block_fits_in_a_single_inscription() {
         let max_block_size = usize::try_from(crate::config::default_max_block_size().as_u64())

--- a/lez/sequencer/core/src/block_publisher.rs
+++ b/lez/sequencer/core/src/block_publisher.rs
@@ -536,3 +536,71 @@ pub async fn post_channel_config(
         .await
         .context("Failed to post channel config transaction")
 }
+
+#[cfg(test)]
+mod tests {
+    use common::{
+        HashType, block::HashableBlockData, test_utils::sequencer_sign_key_for_testing,
+        transaction::LeeTransaction,
+    };
+
+    use super::*;
+
+    /// Any block that passes the sequencer's own `max_block_size` admission check must also fit
+    /// into a single base-layer `ChannelInscribe` inscription, otherwise the block is built and
+    /// committed to local storage but `publish_block` can never inscribe it on Bedrock, silently
+    /// losing its transactions.
+    ///
+    /// Currently fails: the default `max_block_size` (1 MiB) exceeds the base layer's inscription
+    /// cap (`Inscription::MAX` = `MAX_BLOCK_SIZE * 7 / 8` = 917 504 bytes), so any block sized in
+    /// the 917 505..=1 048 576 byte gap passes zone validation but is rejected by the
+    /// `Vec<u8> -> Inscription` conversion in `publish_block`. Deploying several programs in one
+    /// block (e.g. the scaffold's bundled examples) lands in this gap in practice.
+    #[test]
+    fn max_sized_block_fits_in_a_single_inscription() {
+        let max_block_size = usize::try_from(crate::config::default_max_block_size().as_u64())
+            .expect("`max_block_size` should fit into usize");
+
+        // The sequencer's size check (`build_block_from_mempool`) measures the serialized
+        // `HashableBlockData`. Pad a single deployment transaction so the block lands exactly at
+        // the admission limit; the padding bytecode never executes, only its size matters.
+        let block_with_bytecode = |bytecode: Vec<u8>| HashableBlockData {
+            block_id: 2,
+            prev_block_hash: HashType([0; 32]),
+            timestamp: 0,
+            transactions: vec![LeeTransaction::ProgramDeployment(
+                lee::ProgramDeploymentTransaction::new(
+                    lee::program_deployment_transaction::Message::new(bytecode),
+                ),
+            )],
+        };
+
+        let framing = borsh::to_vec(&block_with_bytecode(vec![]))
+            .expect("Failed to serialize empty block")
+            .len();
+        let hashable_data = block_with_bytecode(vec![0_u8; max_block_size - framing]);
+
+        let block_size = borsh::to_vec(&hashable_data)
+            .expect("Failed to serialize block for size check")
+            .len();
+        assert!(
+            block_size <= max_block_size,
+            "test bug: block of {block_size} bytes would already be rejected by the sequencer"
+        );
+
+        // Same conversion `publish_block` performs on the full signed block.
+        let block = hashable_data.into_pending_block(&sequencer_sign_key_for_testing());
+        let data = borsh::to_vec(&block).expect("Failed to serialize block");
+        let published_size = data.len();
+        let result: Result<Inscription, _> = data.try_into();
+
+        assert!(
+            result.is_ok(),
+            "block of {block_size} bytes passed the sequencer's max_block_size check \
+             ({max_block_size} bytes) but its {published_size}-byte inscription payload exceeds \
+             the base layer's cap of {} bytes: {:?}",
+            Inscription::MAX,
+            result.unwrap_err(),
+        );
+    }
+}

--- a/lez/sequencer/core/src/config.rs
+++ b/lez/sequencer/core/src/config.rs
@@ -85,6 +85,6 @@ impl SequencerConfig {
     }
 }
 
-const fn default_max_block_size() -> ByteSize {
+pub(crate) const fn default_max_block_size() -> ByteSize {
     ByteSize::mib(1)
 }


### PR DESCRIPTION
## Summary

Adds a regression test for the sequencer block size / base-layer inscription cap mismatch reported in https://gist.github.com/kamikazebr/ae214c70ea4820df9b8e96b8281d179b.

**Status update:** the bug reproduced when this branch was based on 415964d7 (base layer pinned at logos-blockchain@d8711bbc, inscription cap = 917,504 B vs the 1 MiB default `max_block_size`):

```
block of 1048576 bytes passed the sequencer's max_block_size check (1048576 bytes)
but its 1048673-byte inscription payload exceeds the base layer's cap of 917504 bytes:
TooLong { actual: 1048673, max: 917504 }
```

After rebasing onto current main, the logos-blockchain bump to 0dc34e2c raised `MAX_BLOCK_TRANSACTIONS_SIZE` to 2 MiB, putting the inscription cap at 1,835,008 B — above the zone's limit. So the reported gap is closed on main and **the test now passes**, serving as a guard against either limit drifting back out of range, since nothing in the code ties them together.

## The test

`max_sized_block_fits_in_a_single_inscription` (in `block_publisher.rs`):

1. Builds a block padded to exactly the default `max_block_size`, and asserts it passes the same size check `build_block_from_mempool` performs.
2. Runs the same `Vec<u8> -> Inscription` conversion `publish_block` performs on the full signed block and asserts it succeeds. If it ever fails, blocks in the gap are committed to local storage but can never be inscribed on Bedrock, silently losing their transactions.

## Notes

- The inscribed payload is the full signed `Block`, slightly larger (+97 B) than the `HashableBlockData` the admission check measures — the test covers that framing difference too.
- `default_max_block_size` is now `pub(crate)` so the test tracks the real default instead of a hardcoded copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)