### PR TITLE
feat(cross-zone): add CACP inscription protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1330,9 +1330,15 @@ name = "cacp_demo"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "authenticated_transfer_core",
  "cross_zone",
+ "lee",
  "logos-blockchain-core",
  "logos-blockchain-key-management-system-service",
+ "programs",
+ "serde",
+ "testnet_initial_state",
+ "vault_core",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1326,6 +1326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cacp_demo"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "cross_zone",
+ "logos-blockchain-core",
+ "logos-blockchain-key-management-system-service",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1981,10 +1991,14 @@ dependencies = [
  "cross_zone_inbox_core",
  "lee",
  "lee_core",
+ "logos-blockchain-core",
+ "logos-blockchain-key-management-system-service",
  "ping_core",
  "programs",
  "risc0-zkvm",
  "serde",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "wrapped_token_core",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ members = [
   "tools/integration_bench",
   "tools/cross_zone_chat",
   "tools/dashboard_gen",
+  "tools/cacp_demo",
 ]
 
 [workspace.dependencies]

--- a/Justfile
+++ b/Justfile
@@ -151,10 +151,10 @@ cross-zone-chat:
     @echo "💬 Cross-zone chat demo — open the printed localhost URL"
     {{DEMO_ENV}} RISC0_DEV_MODE=1 cargo run -p cross_zone_chat --release
 
-# Demo: two-zone CACP reference model. Runs four asserted protocol scenarios;
-# inscriptions do not provide stake custody or costly-abort enforcement.
+# Demo: two-zone CACP plus a real LEZ public-account custody scenario.
+# Inscriptions remain data; a separate vault/resolver flow enforces the payout.
 demo-cacp:
-    @echo "🔐 CACP reference-model demo"
+    @echo "🔐 CACP + external LEZ bond demo"
     cargo run -p cacp_demo
 
 # Clean runtime data

--- a/Justfile
+++ b/Justfile
@@ -151,6 +151,12 @@ cross-zone-chat:
     @echo "💬 Cross-zone chat demo — open the printed localhost URL"
     {{DEMO_ENV}} RISC0_DEV_MODE=1 cargo run -p cross_zone_chat --release
 
+# Demo: two-zone CACP reference model. Runs four asserted protocol scenarios;
+# inscriptions do not provide stake custody or costly-abort enforcement.
+demo-cacp:
+    @echo "🔐 CACP reference-model demo"
+    cargo run -p cacp_demo
+
 # Clean runtime data
 clean:
     @echo "🧹 Cleaning run artifacts"

--- a/lez/cross_zone/Cargo.toml
+++ b/lez/cross_zone/Cargo.toml
@@ -17,3 +17,7 @@ ping_core.workspace = true
 wrapped_token_core.workspace = true
 serde.workspace = true
 risc0-zkvm.workspace = true
+logos-blockchain-core.workspace = true
+logos-blockchain-key-management-system-service.workspace = true
+sha2.workspace = true
+thiserror.workspace = true

--- a/lez/cross_zone/src/cacp.rs
+++ b/lez/cross_zone/src/cacp.rs
@@ -1,8 +1,9 @@
 //! Two-sequencer CACP reference implementation for L1 channel inscriptions.
 //!
-//! This module coordinates and validates one joint Mantle transaction. It does
-//! not implement stake custody or forfeiture: `ChannelInscribe` payloads are
-//! data, not executable bond operations.
+//! This module coordinates and validates one joint Mantle transaction.
+//! `ChannelInscribe` payloads remain data, not executable bond operations. An
+//! intent may bind terms for a separately executed custodial bond, but custody
+//! and settlement must happen in that external execution environment.
 
 use std::collections::{HashMap, HashSet};
 
@@ -31,11 +32,23 @@ pub struct InscribeIntent {
     pub payload: Vec<u8>,
 }
 
+/// Economic terms enforced outside Bedrock by an explicitly named custodian.
+///
+/// The enforcer is a LEE public account. Binding it into the proposal does not
+/// make inscriptions executable; it lets both sequencers agree which separate
+/// custody flow and stake amount belong to this CACP run.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct CustodialBondTerms {
+    pub enforcer_account_id: lee::AccountId,
+    pub stake_amount: u128,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct CrossZoneIntent {
     version: u8,
     operations: [InscribeIntent; PARTICIPANT_COUNT],
     nonce: u64,
+    custodial_bond: Option<CustodialBondTerms>,
 }
 
 impl CrossZoneIntent {
@@ -64,7 +77,17 @@ impl CrossZoneIntent {
             version: INTENT_VERSION,
             operations,
             nonce,
+            custodial_bond: None,
         })
+    }
+
+    /// Binds a separately executed custodial bond to this proposal.
+    pub fn with_custodial_bond(mut self, terms: CustodialBondTerms) -> Result<Self, CacpError> {
+        if terms.stake_amount == 0 {
+            return Err(CacpError::ZeroStake);
+        }
+        self.custodial_bond = Some(terms);
+        Ok(self)
     }
 
     #[must_use]
@@ -82,6 +105,11 @@ impl CrossZoneIntent {
         self.nonce
     }
 
+    #[must_use]
+    pub const fn custodial_bond(&self) -> Option<CustodialBondTerms> {
+        self.custodial_bond
+    }
+
     /// Fixed-field-order encoding used to identify one CACP proposal.
     #[must_use]
     pub fn canonical_bytes(&self) -> Vec<u8> {
@@ -96,6 +124,11 @@ impl CrossZoneIntent {
             bytes.extend_from_slice(&operation.payload);
         }
         bytes.extend_from_slice(&self.nonce.to_le_bytes());
+        if let Some(terms) = self.custodial_bond {
+            bytes.extend_from_slice(b"/CACP/CustodialBond/v1/");
+            bytes.extend_from_slice(terms.enforcer_account_id.as_ref());
+            bytes.extend_from_slice(&terms.stake_amount.to_le_bytes());
+        }
         bytes
     }
 
@@ -499,6 +532,8 @@ pub enum CacpError {
     EmptyInscription,
     #[error("an inscription exceeds the Mantle bound")]
     InscriptionTooLarge,
+    #[error("a custodial bond stake must be greater than zero")]
+    ZeroStake,
     #[error("the intent does not match the fixed two-zone topology")]
     TopologyMismatch,
     #[error("a channel parent is missing")]
@@ -697,6 +732,46 @@ mod tests {
             topology,
             parents,
         }
+    }
+
+    #[test]
+    fn custodial_bond_terms_are_bound_to_the_proposal() {
+        let fixture = fixture();
+        let first = fixture
+            .intent
+            .clone()
+            .with_custodial_bond(CustodialBondTerms {
+                enforcer_account_id: lee::AccountId::new([9; 32]),
+                stake_amount: 1_000,
+            })
+            .unwrap();
+        let different_amount = fixture
+            .intent
+            .clone()
+            .with_custodial_bond(CustodialBondTerms {
+                enforcer_account_id: lee::AccountId::new([9; 32]),
+                stake_amount: 2_000,
+            })
+            .unwrap();
+        let different_enforcer = fixture
+            .intent
+            .clone()
+            .with_custodial_bond(CustodialBondTerms {
+                enforcer_account_id: lee::AccountId::new([8; 32]),
+                stake_amount: 1_000,
+            })
+            .unwrap();
+
+        assert_ne!(first.proposal_id(), fixture.intent.proposal_id());
+        assert_ne!(first.proposal_id(), different_amount.proposal_id());
+        assert_ne!(first.proposal_id(), different_enforcer.proposal_id());
+        assert!(matches!(
+            fixture.intent.with_custodial_bond(CustodialBondTerms {
+                enforcer_account_id: lee::AccountId::new([9; 32]),
+                stake_amount: 0,
+            }),
+            Err(CacpError::ZeroStake)
+        ));
     }
 
     fn phase_three(fixture: &Fixture) -> (InitiatorSession, CounterpartySession, Finalize) {

--- a/lez/cross_zone/src/cacp.rs
+++ b/lez/cross_zone/src/cacp.rs
@@ -1,0 +1,841 @@
+//! Two-sequencer CACP reference implementation for L1 channel inscriptions.
+//!
+//! This module coordinates and validates one joint Mantle transaction. It does
+//! not implement stake custody or forfeiture: `ChannelInscribe` payloads are
+//! data, not executable bond operations.
+
+use std::collections::{HashMap, HashSet};
+
+use logos_blockchain_core::mantle::{
+    SignedMantleTx,
+    ops::{
+        Op, OpProof,
+        channel::{
+            ChannelId, Ed25519PublicKey, MsgId,
+            inscribe::{Inscription, InscriptionOp},
+        },
+    },
+    traits::Hashable as _,
+    transactions::{MantleTx, MantleTxBuilder, OpsProofs, TxHash, states::Unverified},
+};
+use logos_blockchain_key_management_system_service::keys::{Ed25519Key, Ed25519Signature};
+use sha2::{Digest as _, Sha256};
+use thiserror::Error;
+
+pub const INTENT_VERSION: u8 = 1;
+pub const PARTICIPANT_COUNT: usize = 2;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct InscribeIntent {
+    pub channel_id: ChannelId,
+    pub payload: Vec<u8>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossZoneIntent {
+    version: u8,
+    operations: [InscribeIntent; PARTICIPANT_COUNT],
+    nonce: u64,
+}
+
+impl CrossZoneIntent {
+    pub fn new(
+        mut operations: [InscribeIntent; PARTICIPANT_COUNT],
+        nonce: u64,
+    ) -> Result<Self, CacpError> {
+        operations.sort_by(|left, right| left.channel_id.as_ref().cmp(right.channel_id.as_ref()));
+        if operations[0].channel_id == operations[1].channel_id {
+            return Err(CacpError::DuplicateChannel);
+        }
+        if operations
+            .iter()
+            .any(|operation| operation.payload.is_empty())
+        {
+            return Err(CacpError::EmptyInscription);
+        }
+        for operation in &operations {
+            let _bounded: Inscription = operation
+                .payload
+                .clone()
+                .try_into()
+                .map_err(|_error| CacpError::InscriptionTooLarge)?;
+        }
+        Ok(Self {
+            version: INTENT_VERSION,
+            operations,
+            nonce,
+        })
+    }
+
+    #[must_use]
+    pub const fn version(&self) -> u8 {
+        self.version
+    }
+
+    #[must_use]
+    pub const fn operations(&self) -> &[InscribeIntent; PARTICIPANT_COUNT] {
+        &self.operations
+    }
+
+    #[must_use]
+    pub const fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    /// Fixed-field-order encoding used to identify one CACP proposal.
+    #[must_use]
+    pub fn canonical_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        bytes.push(self.version);
+        bytes.extend_from_slice(&2_u32.to_le_bytes());
+        for operation in &self.operations {
+            bytes.extend_from_slice(operation.channel_id.as_ref());
+            let payload_len = u64::try_from(operation.payload.len())
+                .expect("an inscription length must fit in u64");
+            bytes.extend_from_slice(&payload_len.to_le_bytes());
+            bytes.extend_from_slice(&operation.payload);
+        }
+        bytes.extend_from_slice(&self.nonce.to_le_bytes());
+        bytes
+    }
+
+    #[must_use]
+    pub fn proposal_id(&self) -> ProposalId {
+        ProposalId(Sha256::digest(self.canonical_bytes()).into())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct ProposalId(pub [u8; 32]);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ZoneSequencer {
+    pub channel_id: ChannelId,
+    pub public_key: Ed25519PublicKey,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TwoZoneTopology {
+    pub initiator: ZoneSequencer,
+    pub counterparty: ZoneSequencer,
+}
+
+impl TwoZoneTopology {
+    pub fn new(
+        initiator: ZoneSequencer,
+        counterparty: ZoneSequencer,
+        intent: &CrossZoneIntent,
+    ) -> Result<Self, CacpError> {
+        if initiator.channel_id == counterparty.channel_id {
+            return Err(CacpError::DuplicateChannel);
+        }
+        if initiator.public_key == counterparty.public_key {
+            return Err(CacpError::DuplicateSequencer);
+        }
+        let participant_channels = [initiator.channel_id, counterparty.channel_id];
+        if intent
+            .operations
+            .iter()
+            .any(|operation| !participant_channels.contains(&operation.channel_id))
+        {
+            return Err(CacpError::TopologyMismatch);
+        }
+        Ok(Self {
+            initiator,
+            counterparty,
+        })
+    }
+
+    fn sequencer_for(&self, channel_id: ChannelId) -> Option<&ZoneSequencer> {
+        [&self.initiator, &self.counterparty]
+            .into_iter()
+            .find(|sequencer| sequencer.channel_id == channel_id)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ChannelParent {
+    pub channel_id: ChannelId,
+    pub parent: MsgId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Propose {
+    pub intent: CrossZoneIntent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Accept {
+    pub tx: MantleTx,
+    pub counterparty_proof: Ed25519Signature,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Finalize {
+    pub signed_tx: SignedMantleTx<Unverified>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Phase {
+    WaitingForAccept,
+    WaitingForFinalize,
+    SignaturesExchanged,
+    Submitted,
+    Aborted,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TimeoutOutcome {
+    Aborted,
+    FallbackSubmission(SignedMantleTx<Unverified>),
+    NoAction,
+}
+
+pub struct InitiatorSession {
+    topology: TwoZoneTopology,
+    intent: CrossZoneIntent,
+    parents: [ChannelParent; PARTICIPANT_COUNT],
+    phase: Phase,
+    signed_tx: Option<SignedMantleTx<Unverified>>,
+}
+
+impl InitiatorSession {
+    pub fn new(
+        topology: TwoZoneTopology,
+        intent: CrossZoneIntent,
+        parents: [ChannelParent; PARTICIPANT_COUNT],
+    ) -> Result<Self, CacpError> {
+        validate_parents(&intent, &parents)?;
+        Ok(Self {
+            topology,
+            intent,
+            parents,
+            phase: Phase::WaitingForAccept,
+            signed_tx: None,
+        })
+    }
+
+    #[must_use]
+    pub fn propose(&self) -> Propose {
+        Propose {
+            intent: self.intent.clone(),
+        }
+    }
+
+    #[must_use]
+    pub const fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    pub fn receive_accept(
+        &mut self,
+        accept: Accept,
+        signing_key: &Ed25519Key,
+    ) -> Result<Finalize, CacpError> {
+        if self.phase != Phase::WaitingForAccept {
+            return Err(CacpError::UnexpectedPhase);
+        }
+        require_key(signing_key, &self.topology.initiator)?;
+        validate_joint_tx(&accept.tx, &self.intent, &self.topology, &self.parents)?;
+
+        let tx_hash = accept.tx.hash();
+        self.topology
+            .counterparty
+            .public_key
+            .verify(
+                tx_hash.as_signing_bytes().as_ref(),
+                &accept.counterparty_proof,
+            )
+            .map_err(|_error| CacpError::InvalidCounterpartyProof)?;
+
+        let initiator_proof = signing_key.sign_payload(tx_hash.as_signing_bytes().as_ref());
+        let proofs = proofs_in_operation_order(
+            &accept.tx,
+            &self.topology,
+            initiator_proof,
+            accept.counterparty_proof,
+        )?;
+        let signed_tx = SignedMantleTx::new(accept.tx, proofs);
+        signed_tx
+            .clone()
+            .preverify()
+            .map_err(|_error| CacpError::InvalidSignedTransaction)?;
+
+        self.phase = Phase::SignaturesExchanged;
+        self.signed_tx = Some(signed_tx.clone());
+        Ok(Finalize { signed_tx })
+    }
+
+    pub const fn on_timeout(&mut self) -> TimeoutOutcome {
+        match self.phase {
+            Phase::WaitingForAccept | Phase::WaitingForFinalize => {
+                self.phase = Phase::Aborted;
+                TimeoutOutcome::Aborted
+            }
+            Phase::SignaturesExchanged | Phase::Submitted | Phase::Aborted => {
+                TimeoutOutcome::NoAction
+            }
+        }
+    }
+
+    pub fn mark_submitted(&mut self) -> Result<(), CacpError> {
+        if self.phase != Phase::SignaturesExchanged {
+            return Err(CacpError::UnexpectedPhase);
+        }
+        self.phase = Phase::Submitted;
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn signed_tx(&self) -> Option<&SignedMantleTx<Unverified>> {
+        self.signed_tx.as_ref()
+    }
+}
+
+pub struct CounterpartySession {
+    topology: TwoZoneTopology,
+    expected_intent: CrossZoneIntent,
+    parents: [ChannelParent; PARTICIPANT_COUNT],
+    phase: Phase,
+    accepted_tx: Option<MantleTx>,
+    signed_tx: Option<SignedMantleTx<Unverified>>,
+}
+
+impl CounterpartySession {
+    pub fn new(
+        topology: TwoZoneTopology,
+        expected_intent: CrossZoneIntent,
+        parents: [ChannelParent; PARTICIPANT_COUNT],
+    ) -> Result<Self, CacpError> {
+        validate_parents(&expected_intent, &parents)?;
+        Ok(Self {
+            topology,
+            expected_intent,
+            parents,
+            phase: Phase::WaitingForAccept,
+            accepted_tx: None,
+            signed_tx: None,
+        })
+    }
+
+    pub fn receive_propose(
+        &mut self,
+        propose: &Propose,
+        signing_key: &Ed25519Key,
+    ) -> Result<Accept, CacpError> {
+        if self.phase != Phase::WaitingForAccept {
+            return Err(CacpError::UnexpectedPhase);
+        }
+        if propose.intent != self.expected_intent {
+            return Err(CacpError::IntentMismatch);
+        }
+        require_key(signing_key, &self.topology.counterparty)?;
+        let tx = build_joint_tx(&propose.intent, &self.topology, &self.parents)?;
+        let proof = signing_key.sign_payload(tx.hash().as_signing_bytes().as_ref());
+        self.phase = Phase::WaitingForFinalize;
+        self.accepted_tx = Some(tx.clone());
+        Ok(Accept {
+            tx,
+            counterparty_proof: proof,
+        })
+    }
+
+    pub fn receive_finalize(&mut self, finalize: Finalize) -> Result<(), CacpError> {
+        if self.phase != Phase::WaitingForFinalize {
+            return Err(CacpError::UnexpectedPhase);
+        }
+        let accepted_tx = self
+            .accepted_tx
+            .as_ref()
+            .ok_or(CacpError::UnexpectedPhase)?;
+        if finalize.signed_tx.mantle_tx() != accepted_tx {
+            return Err(CacpError::TransactionMismatch);
+        }
+        finalize
+            .signed_tx
+            .clone()
+            .preverify()
+            .map_err(|_error| CacpError::InvalidSignedTransaction)?;
+        self.phase = Phase::SignaturesExchanged;
+        self.signed_tx = Some(finalize.signed_tx);
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn phase(&self) -> Phase {
+        self.phase
+    }
+
+    pub fn on_timeout(&mut self) -> TimeoutOutcome {
+        match self.phase {
+            Phase::WaitingForAccept | Phase::WaitingForFinalize => {
+                self.phase = Phase::Aborted;
+                TimeoutOutcome::Aborted
+            }
+            Phase::SignaturesExchanged => self
+                .signed_tx
+                .as_ref()
+                .map_or(TimeoutOutcome::NoAction, |signed_tx| {
+                    TimeoutOutcome::FallbackSubmission(signed_tx.clone())
+                }),
+            Phase::Submitted | Phase::Aborted => TimeoutOutcome::NoAction,
+        }
+    }
+
+    pub fn mark_submitted(&mut self) -> Result<(), CacpError> {
+        if self.phase != Phase::SignaturesExchanged {
+            return Err(CacpError::UnexpectedPhase);
+        }
+        self.phase = Phase::Submitted;
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn signed_tx(&self) -> Option<&SignedMantleTx<Unverified>> {
+        self.signed_tx.as_ref()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubmittedBy {
+    Initiator,
+    CounterpartyFallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SubmissionResult {
+    Included(TxHash),
+    AlreadyIncluded(TxHash),
+}
+
+/// Atomic, in-memory model of the single Bedrock used by this demo.
+pub struct BedrockModel {
+    tips: HashMap<ChannelId, MsgId>,
+    included: HashSet<TxHash>,
+    submitters: HashMap<TxHash, SubmittedBy>,
+}
+
+impl BedrockModel {
+    #[must_use]
+    pub fn new(parents: [ChannelParent; PARTICIPANT_COUNT]) -> Self {
+        Self {
+            tips: parents
+                .into_iter()
+                .map(|parent| (parent.channel_id, parent.parent))
+                .collect(),
+            included: HashSet::new(),
+            submitters: HashMap::new(),
+        }
+    }
+
+    pub fn submit(
+        &mut self,
+        signed_tx: &SignedMantleTx<Unverified>,
+        submitted_by: SubmittedBy,
+    ) -> Result<SubmissionResult, BedrockError> {
+        let tx_hash = signed_tx.hash();
+        if self.included.contains(&tx_hash) {
+            return Ok(SubmissionResult::AlreadyIncluded(tx_hash));
+        }
+        signed_tx
+            .clone()
+            .preverify()
+            .map_err(|_error| BedrockError::InvalidProof)?;
+        let ops = signed_tx.mantle_tx().ops();
+        if ops.len() != PARTICIPANT_COUNT
+            || ops
+                .iter()
+                .any(|operation| !matches!(operation, Op::ChannelInscribe(_)))
+        {
+            return Err(BedrockError::InvalidShape);
+        }
+
+        let mut next_tips = Vec::with_capacity(PARTICIPANT_COUNT);
+        let mut seen = HashSet::new();
+        for operation in ops {
+            let Op::ChannelInscribe(inscription) = operation else {
+                return Err(BedrockError::InvalidShape);
+            };
+            if !seen.insert(inscription.channel_id) {
+                return Err(BedrockError::InvalidShape);
+            }
+            let current = self
+                .tips
+                .get(&inscription.channel_id)
+                .ok_or(BedrockError::UnknownChannel)?;
+            if *current != inscription.parent {
+                return Err(BedrockError::StaleParent);
+            }
+            next_tips.push((inscription.channel_id, inscription.id()));
+        }
+
+        // Commit only after every operation has validated.
+        for (channel_id, tip) in next_tips {
+            self.tips.insert(channel_id, tip);
+        }
+        self.included.insert(tx_hash);
+        self.submitters.insert(tx_hash, submitted_by);
+        Ok(SubmissionResult::Included(tx_hash))
+    }
+
+    #[must_use]
+    pub fn tip(&self, channel_id: ChannelId) -> Option<MsgId> {
+        self.tips.get(&channel_id).copied()
+    }
+
+    #[must_use]
+    pub fn submitted_by(&self, tx_hash: TxHash) -> Option<SubmittedBy> {
+        self.submitters.get(&tx_hash).copied()
+    }
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum CacpError {
+    #[error("the two zones must use distinct channels")]
+    DuplicateChannel,
+    #[error("the two zones must use distinct sequencer keys")]
+    DuplicateSequencer,
+    #[error("an inscription payload cannot be empty")]
+    EmptyInscription,
+    #[error("an inscription exceeds the Mantle bound")]
+    InscriptionTooLarge,
+    #[error("the intent does not match the fixed two-zone topology")]
+    TopologyMismatch,
+    #[error("a channel parent is missing")]
+    MissingParent,
+    #[error("the session is not in the required phase")]
+    UnexpectedPhase,
+    #[error("the proposal differs from the pre-agreed intent")]
+    IntentMismatch,
+    #[error("the accepting sequencer returned a different transaction")]
+    TransactionMismatch,
+    #[error("the supplied private key does not belong to this sequencer")]
+    WrongSequencerKey,
+    #[error("the counterparty signature is invalid")]
+    InvalidCounterpartyProof,
+    #[error("the joint transaction is not exactly two channel inscriptions")]
+    InvalidJointTransaction,
+    #[error("the fully signed transaction is invalid")]
+    InvalidSignedTransaction,
+}
+
+#[derive(Debug, Error, Eq, PartialEq)]
+pub enum BedrockError {
+    #[error("the transaction is not exactly two ChannelInscribe operations")]
+    InvalidShape,
+    #[error("a ChannelInscribe signature is invalid")]
+    InvalidProof,
+    #[error("the transaction references a channel outside this demo")]
+    UnknownChannel,
+    #[error("at least one channel parent is stale")]
+    StaleParent,
+}
+
+pub fn build_joint_tx(
+    intent: &CrossZoneIntent,
+    topology: &TwoZoneTopology,
+    parents: &[ChannelParent; PARTICIPANT_COUNT],
+) -> Result<MantleTx, CacpError> {
+    validate_parents(intent, parents)?;
+    let mut builder = MantleTxBuilder::new();
+    for operation in intent.operations() {
+        let sequencer = topology
+            .sequencer_for(operation.channel_id)
+            .ok_or(CacpError::TopologyMismatch)?;
+        let parent = parents
+            .iter()
+            .find(|parent| parent.channel_id == operation.channel_id)
+            .ok_or(CacpError::MissingParent)?;
+        let inscription = operation
+            .payload
+            .clone()
+            .try_into()
+            .map_err(|_error| CacpError::InscriptionTooLarge)?;
+        builder = builder
+            .push_op(Op::ChannelInscribe(InscriptionOp {
+                channel_id: operation.channel_id,
+                inscription,
+                parent: parent.parent,
+                signer: sequencer.public_key,
+            }))
+            .map_err(|_error| CacpError::InvalidJointTransaction)?;
+    }
+    builder
+        .build()
+        .map_err(|_error| CacpError::InvalidJointTransaction)
+}
+
+fn validate_joint_tx(
+    tx: &MantleTx,
+    intent: &CrossZoneIntent,
+    topology: &TwoZoneTopology,
+    parents: &[ChannelParent; PARTICIPANT_COUNT],
+) -> Result<(), CacpError> {
+    let expected = build_joint_tx(intent, topology, parents)?;
+    if *tx == expected {
+        Ok(())
+    } else {
+        Err(CacpError::TransactionMismatch)
+    }
+}
+
+fn proofs_in_operation_order(
+    tx: &MantleTx,
+    topology: &TwoZoneTopology,
+    initiator_proof: Ed25519Signature,
+    counterparty_proof: Ed25519Signature,
+) -> Result<OpsProofs, CacpError> {
+    #[expect(
+        clippy::wildcard_enum_match_arm,
+        reason = "only ChannelInscribe belongs in the locked demo scope"
+    )]
+    let proofs = tx
+        .ops()
+        .iter()
+        .map(|operation| match operation {
+            Op::ChannelInscribe(inscription)
+                if inscription.channel_id == topology.initiator.channel_id =>
+            {
+                Ok(OpProof::Ed25519Sig(initiator_proof))
+            }
+            Op::ChannelInscribe(inscription)
+                if inscription.channel_id == topology.counterparty.channel_id =>
+            {
+                Ok(OpProof::Ed25519Sig(counterparty_proof))
+            }
+            _ => Err(CacpError::InvalidJointTransaction),
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    OpsProofs::try_from(proofs).map_err(|_error| CacpError::InvalidJointTransaction)
+}
+
+fn validate_parents(
+    intent: &CrossZoneIntent,
+    parents: &[ChannelParent; PARTICIPANT_COUNT],
+) -> Result<(), CacpError> {
+    if parents[0].channel_id == parents[1].channel_id {
+        return Err(CacpError::DuplicateChannel);
+    }
+    if intent.operations.iter().any(|operation| {
+        !parents
+            .iter()
+            .any(|parent| parent.channel_id == operation.channel_id)
+    }) {
+        return Err(CacpError::MissingParent);
+    }
+    Ok(())
+}
+
+fn require_key(key: &Ed25519Key, sequencer: &ZoneSequencer) -> Result<(), CacpError> {
+    if key.public_key() == sequencer.public_key {
+        Ok(())
+    } else {
+        Err(CacpError::WrongSequencerKey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY_A: [u8; 32] = [0xA1; 32];
+    const KEY_B: [u8; 32] = [0xB2; 32];
+
+    struct Fixture {
+        key_a: Ed25519Key,
+        key_b: Ed25519Key,
+        intent: CrossZoneIntent,
+        topology: TwoZoneTopology,
+        parents: [ChannelParent; PARTICIPANT_COUNT],
+    }
+
+    fn fixture() -> Fixture {
+        let key_a = Ed25519Key::from_bytes(&KEY_A);
+        let key_b = Ed25519Key::from_bytes(&KEY_B);
+        let channel_a = ChannelId::from([1; 32]);
+        let channel_b = ChannelId::from([2; 32]);
+        let intent = CrossZoneIntent::new(
+            [
+                InscribeIntent {
+                    channel_id: channel_b,
+                    payload: b"zone-b-block".to_vec(),
+                },
+                InscribeIntent {
+                    channel_id: channel_a,
+                    payload: b"zone-a-block".to_vec(),
+                },
+            ],
+            42,
+        )
+        .unwrap();
+        let topology = TwoZoneTopology::new(
+            ZoneSequencer {
+                channel_id: channel_a,
+                public_key: key_a.public_key(),
+            },
+            ZoneSequencer {
+                channel_id: channel_b,
+                public_key: key_b.public_key(),
+            },
+            &intent,
+        )
+        .unwrap();
+        let parents = [
+            ChannelParent {
+                channel_id: channel_a,
+                parent: MsgId::from([3; 32]),
+            },
+            ChannelParent {
+                channel_id: channel_b,
+                parent: MsgId::from([4; 32]),
+            },
+        ];
+        Fixture {
+            key_a,
+            key_b,
+            intent,
+            topology,
+            parents,
+        }
+    }
+
+    fn phase_three(fixture: &Fixture) -> (InitiatorSession, CounterpartySession, Finalize) {
+        let mut initiator = InitiatorSession::new(
+            fixture.topology.clone(),
+            fixture.intent.clone(),
+            fixture.parents,
+        )
+        .unwrap();
+        let mut counterparty = CounterpartySession::new(
+            fixture.topology.clone(),
+            fixture.intent.clone(),
+            fixture.parents,
+        )
+        .unwrap();
+        let accept = counterparty
+            .receive_propose(&initiator.propose(), &fixture.key_b)
+            .unwrap();
+        let finalize = initiator.receive_accept(accept, &fixture.key_a).unwrap();
+        counterparty.receive_finalize(finalize.clone()).unwrap();
+        (initiator, counterparty, finalize)
+    }
+
+    #[test]
+    fn joint_transaction_has_only_two_channel_inscriptions() {
+        let fixture = fixture();
+        let tx = build_joint_tx(&fixture.intent, &fixture.topology, &fixture.parents).unwrap();
+        assert_eq!(tx.ops().len(), 2);
+        assert!(
+            tx.ops()
+                .iter()
+                .all(|operation| matches!(operation, Op::ChannelInscribe(_)))
+        );
+    }
+
+    #[test]
+    fn happy_path_gives_both_sequencers_the_same_atomic_transaction() {
+        let fixture = fixture();
+        let (mut initiator, mut counterparty, finalize) = phase_three(&fixture);
+        assert_eq!(initiator.signed_tx(), counterparty.signed_tx());
+
+        let mut bedrock = BedrockModel::new(fixture.parents);
+        let included = bedrock
+            .submit(&finalize.signed_tx, SubmittedBy::Initiator)
+            .unwrap();
+        let SubmissionResult::Included(tx_hash) = included else {
+            panic!("first submission must be included");
+        };
+        initiator.mark_submitted().unwrap();
+        counterparty.mark_submitted().unwrap();
+        assert_eq!(bedrock.submitted_by(tx_hash), Some(SubmittedBy::Initiator));
+        assert_eq!(initiator.phase(), Phase::Submitted);
+        assert_eq!(counterparty.phase(), Phase::Submitted);
+        assert_ne!(
+            bedrock.tip(fixture.topology.initiator.channel_id),
+            Some(fixture.parents[0].parent)
+        );
+        assert_ne!(
+            bedrock.tip(fixture.topology.counterparty.channel_id),
+            Some(fixture.parents[1].parent)
+        );
+    }
+
+    #[test]
+    fn counterparty_fallback_submits_after_phase_three() {
+        let fixture = fixture();
+        let (_initiator, mut counterparty, _finalize) = phase_three(&fixture);
+        let TimeoutOutcome::FallbackSubmission(signed_tx) = counterparty.on_timeout() else {
+            panic!("post-Phase-3 timeout must trigger fallback submission");
+        };
+        let mut bedrock = BedrockModel::new(fixture.parents);
+        let included = bedrock
+            .submit(&signed_tx, SubmittedBy::CounterpartyFallback)
+            .unwrap();
+        let SubmissionResult::Included(tx_hash) = included else {
+            panic!("fallback transaction must be included");
+        };
+        assert_eq!(
+            bedrock.submitted_by(tx_hash),
+            Some(SubmittedBy::CounterpartyFallback)
+        );
+        assert_eq!(
+            bedrock.submit(&signed_tx, SubmittedBy::Initiator).unwrap(),
+            SubmissionResult::AlreadyIncluded(tx_hash)
+        );
+    }
+
+    #[test]
+    fn timeout_before_phase_three_aborts_without_a_submittable_transaction() {
+        let fixture = fixture();
+        let mut initiator = InitiatorSession::new(
+            fixture.topology.clone(),
+            fixture.intent.clone(),
+            fixture.parents,
+        )
+        .unwrap();
+        assert_eq!(initiator.on_timeout(), TimeoutOutcome::Aborted);
+        assert_eq!(initiator.phase(), Phase::Aborted);
+        assert!(initiator.signed_tx().is_none());
+
+        let mut counterparty =
+            CounterpartySession::new(fixture.topology, fixture.intent, fixture.parents).unwrap();
+        let _accept = counterparty
+            .receive_propose(&initiator.propose(), &fixture.key_b)
+            .unwrap();
+        assert_eq!(counterparty.on_timeout(), TimeoutOutcome::Aborted);
+        assert!(counterparty.signed_tx().is_none());
+    }
+
+    #[test]
+    fn a_stale_parent_rejects_both_operations_atomically() {
+        let fixture = fixture();
+        let (_initiator, _counterparty, finalize) = phase_three(&fixture);
+        let mut bedrock = BedrockModel::new([
+            ChannelParent {
+                parent: MsgId::from([9; 32]),
+                ..fixture.parents[0]
+            },
+            fixture.parents[1],
+        ]);
+        let other_tip_before = bedrock.tip(fixture.parents[1].channel_id);
+        assert_eq!(
+            bedrock.submit(&finalize.signed_tx, SubmittedBy::Initiator),
+            Err(BedrockError::StaleParent)
+        );
+        assert_eq!(bedrock.tip(fixture.parents[1].channel_id), other_tip_before);
+    }
+
+    #[test]
+    fn proposal_id_is_canonical_over_channel_order() {
+        let fixture = fixture();
+        let reversed = CrossZoneIntent::new(
+            [
+                fixture.intent.operations()[1].clone(),
+                fixture.intent.operations()[0].clone(),
+            ],
+            fixture.intent.nonce(),
+        )
+        .unwrap();
+        assert_eq!(fixture.intent.proposal_id(), reversed.proposal_id());
+    }
+}

--- a/lez/cross_zone/src/lib.rs
+++ b/lez/cross_zone/src/lib.rs
@@ -22,6 +22,8 @@ use lee_core::{
 };
 use serde::Serialize;
 
+pub mod cacp;
+
 /// The cross-zone emission fields a watcher or verifier reads off a source
 /// transaction, common to every emitter program.
 pub struct Emission {

--- a/tools/cacp_demo/Cargo.toml
+++ b/tools/cacp_demo/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "cacp_demo"
+version = "0.1.0"
+edition = "2024"
+license = { workspace = true }
+publish = false
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+cross_zone.workspace = true
+logos-blockchain-core.workspace = true
+logos-blockchain-key-management-system-service.workspace = true

--- a/tools/cacp_demo/Cargo.toml
+++ b/tools/cacp_demo/Cargo.toml
@@ -10,6 +10,12 @@ workspace = true
 
 [dependencies]
 anyhow.workspace = true
+authenticated_transfer_core.workspace = true
 cross_zone.workspace = true
+lee.workspace = true
 logos-blockchain-core.workspace = true
 logos-blockchain-key-management-system-service.workspace = true
+programs.workspace = true
+serde.workspace = true
+testnet_initial_state.workspace = true
+vault_core.workspace = true

--- a/tools/cacp_demo/README.md
+++ b/tools/cacp_demo/README.md
@@ -7,23 +7,27 @@ scope:
 - two distinct zones, each with one sequencer key;
 - one joint Mantle transaction containing exactly two `ChannelInscribe`
   operations;
-- no bridge, token, ping, indexer, web UI, or ZK flow.
+- no bridge, application token, ping, indexer, web UI, or ZK flow;
+- one external LEZ custody step using existing native public-account balances,
+  `authenticated_transfer`, and `vault`.
 
 It is not a live Bedrock node or a pair of running sequencer services. The
 binary exercises the real Mantle transaction and signature types through the
 `cross_zone` CACP state machines and an in-memory atomic Bedrock model.
 
-## Costly Abort boundary
+## Real token commitment and its boundary
 
-Costly Abort is deliberately not implemented by this binary. Logos L1 channel
-inscriptions carry data; they do not execute a vault, lock funds, or seize a
-sequencer's stake. Including a stake amount in an inscription would therefore
-be an unenforceable promise, not a penalty mechanism.
+The fifth scenario executes real LEZ public transactions. Each sequencer signs
+a transfer from its funded public account into a vault PDA controlled by an
+external resolver. LEZ execution decreases both public balances, increases the
+vault balance, rejects a claim signed by a sequencer instead of the resolver,
+and finally transfers the forfeited stake to the honest counterparty.
 
-A real implementation requires an external execution layer with asset custody,
-challenge/response rules, and authenticated receipts for deposit, release, and
-forfeit operations. The current specifications leave the cross-layer proof
-between that enforcer and Bedrock as an open integration question.
+This does not make the inscriptions executable. The CACP intent commits to the
+external enforcer account and stake amount, while custody and settlement are
+separate LEE transactions. The demo's resolver is explicitly trusted to map an
+abort to the correct payout. Replacing that trust with on-chain challenge rules
+and authenticated Bedrock-inclusion evidence remains an integration task.
 
 ## Run
 
@@ -37,7 +41,7 @@ The command exits unsuccessfully if any stated invariant fails. A successful
 run ends with:
 
 ```text
-ALL 4 CACP SCENARIOS PASSED
+ALL 5 CACP SCENARIOS PASSED
 ```
 
 ## Expected scenarios
@@ -50,6 +54,10 @@ ALL 4 CACP SCENARIOS PASSED
    no submittable transaction and advances neither channel.
 4. **Stale-parent rejection:** a stale parent on either inscription rejects the
    entire joint transaction, so neither channel tip changes.
+5. **Real public-account forfeiture:** A and B each deposit 1,000 native units
+   through the LEZ vault program. A cannot reclaim the resolver's PDA. After an
+   externally attributed abort by A, B receives both deposits, leaving A down
+   1,000 and B up 1,000.
 
 For a live presentation, run the single command and read each `PASS` line as
 the expected result for that scenario.

--- a/tools/cacp_demo/README.md
+++ b/tools/cacp_demo/README.md
@@ -1,0 +1,55 @@
+# CACP demo
+
+This command runs a presentation-oriented reference model for the locked demo
+scope:
+
+- one in-memory Bedrock model;
+- two distinct zones, each with one sequencer key;
+- one joint Mantle transaction containing exactly two `ChannelInscribe`
+  operations;
+- no bridge, token, ping, indexer, web UI, or ZK flow.
+
+It is not a live Bedrock node or a pair of running sequencer services. The
+binary exercises the real Mantle transaction and signature types through the
+`cross_zone` CACP state machines and an in-memory atomic Bedrock model.
+
+## Costly Abort boundary
+
+Costly Abort is deliberately not implemented by this binary. Logos L1 channel
+inscriptions carry data; they do not execute a vault, lock funds, or seize a
+sequencer's stake. Including a stake amount in an inscription would therefore
+be an unenforceable promise, not a penalty mechanism.
+
+A real implementation requires an external execution layer with asset custody,
+challenge/response rules, and authenticated receipts for deposit, release, and
+forfeit operations. The current specifications leave the cross-layer proof
+between that enforcer and Bedrock as an open integration question.
+
+## Run
+
+From the repository root:
+
+```console
+just demo-cacp
+```
+
+The command exits unsuccessfully if any stated invariant fails. A successful
+run ends with:
+
+```text
+ALL 4 CACP SCENARIOS PASSED
+```
+
+## Expected scenarios
+
+1. **Happy path:** A proposes, B accepts, A finalizes, and Bedrock includes one
+   jointly signed transaction with two inscriptions.
+2. **B fallback after Phase 3:** once both signatures exist, B can submit the
+   same transaction if A stalls; a later duplicate submission is idempotent.
+3. **Safe abort before Phase 3:** a timeout before both signatures exist leaves
+   no submittable transaction and advances neither channel.
+4. **Stale-parent rejection:** a stale parent on either inscription rejects the
+   entire joint transaction, so neither channel tip changes.
+
+For a live presentation, run the single command and read each `PASS` line as
+the expected result for that scenario.

--- a/tools/cacp_demo/src/main.rs
+++ b/tools/cacp_demo/src/main.rs
@@ -6,9 +6,10 @@
 use anyhow::{Context as _, Result, ensure};
 use cross_zone::cacp::{
     BedrockError, BedrockModel, ChannelParent, CounterpartySession, CrossZoneIntent,
-    InitiatorSession, InscribeIntent, Phase, SubmissionResult, SubmittedBy, TimeoutOutcome,
-    TwoZoneTopology, ZoneSequencer,
+    CustodialBondTerms, InitiatorSession, InscribeIntent, Phase, SubmissionResult, SubmittedBy,
+    TimeoutOutcome, TwoZoneTopology, ZoneSequencer,
 };
+use lee::{AccountId, PrivateKey, PublicKey, PublicTransaction, V03State, public_transaction};
 use logos_blockchain_core::mantle::{
     ops::{
         Op,
@@ -18,26 +19,35 @@ use logos_blockchain_core::mantle::{
 };
 use logos_blockchain_key_management_system_service::keys::Ed25519Key;
 
+const STAKE_AMOUNT: u128 = 1_000;
+
 struct Fixture {
     key_a: Ed25519Key,
     key_b: Ed25519Key,
     intent: CrossZoneIntent,
     topology: TwoZoneTopology,
     parents: [ChannelParent; 2],
+    lee_account_a: AccountId,
+    lee_key_a: PrivateKey,
+    lee_account_b: AccountId,
+    lee_key_b: PrivateKey,
+    bond_enforcer: AccountId,
+    bond_enforcer_key: PrivateKey,
 }
 
 fn main() -> Result<()> {
-    println!("CACP reference-model demo");
+    println!("CACP + externally enforced bond demo");
     println!("Scope: 1 Bedrock | 2 zones | 1 sequencer per zone | 2 ChannelInscribe ops");
-    println!("Note: inscriptions carry data; they do not enforce stake custody or forfeiture.\n");
+    println!("Note: inscriptions carry data; LEZ public-account programs enforce the bond.\n");
 
     let fixture = fixture()?;
     happy_path(&fixture)?;
     counterparty_fallback(&fixture)?;
     safe_pre_phase_three_abort(&fixture)?;
     stale_parent_atomic_rejection(&fixture)?;
+    public_account_stake_forfeiture(&fixture)?;
 
-    println!("\nALL 4 CACP SCENARIOS PASSED");
+    println!("\nALL 5 CACP SCENARIOS PASSED");
     Ok(())
 }
 
@@ -46,6 +56,12 @@ fn fixture() -> Result<Fixture> {
     let key_b = Ed25519Key::from_bytes(&[0xB2; 32]);
     let channel_a = ChannelId::from([1; 32]);
     let channel_b = ChannelId::from([2; 32]);
+    let [lee_a, lee_b] =
+        <[_; 2]>::try_from(testnet_initial_state::initial_pub_accounts_private_keys())
+            .map_err(|_keys| anyhow::anyhow!("testnet must expose exactly two public accounts"))?;
+    let bond_enforcer_key = PrivateKey::try_new([0xC3; 32])
+        .map_err(|error| anyhow::anyhow!("invalid bond enforcer key: {error}"))?;
+    let bond_enforcer = AccountId::from(&PublicKey::new_from_private_key(&bond_enforcer_key));
     let intent = CrossZoneIntent::new(
         [
             InscribeIntent {
@@ -58,7 +74,11 @@ fn fixture() -> Result<Fixture> {
             },
         ],
         7,
-    )?;
+    )?
+    .with_custodial_bond(CustodialBondTerms {
+        enforcer_account_id: bond_enforcer,
+        stake_amount: STAKE_AMOUNT,
+    })?;
     let topology = TwoZoneTopology::new(
         ZoneSequencer {
             channel_id: channel_a,
@@ -86,6 +106,12 @@ fn fixture() -> Result<Fixture> {
         intent,
         topology,
         parents,
+        lee_account_a: lee_a.account_id,
+        lee_key_a: lee_a.pub_sign_key,
+        lee_account_b: lee_b.account_id,
+        lee_key_b: lee_b.pub_sign_key,
+        bond_enforcer,
+        bond_enforcer_key,
     })
 }
 
@@ -233,6 +259,178 @@ fn stale_parent_atomic_rejection(fixture: &Fixture) -> Result<()> {
     Ok(())
 }
 
+fn public_account_stake_forfeiture(fixture: &Fixture) -> Result<()> {
+    heading(5, "real public-account stakes; Sequencer A forfeits");
+    let terms = fixture
+        .intent
+        .custodial_bond()
+        .context("the CACP proposal must bind its external bond terms")?;
+    ensure!(terms.enforcer_account_id == fixture.bond_enforcer);
+    ensure!(terms.stake_amount == STAKE_AMOUNT);
+
+    let mut state = testnet_initial_state::initial_state();
+    let vault_id =
+        vault_core::compute_vault_account_id(programs::vault().id(), fixture.bond_enforcer);
+    let balance_a_before = state.get_account_by_id(fixture.lee_account_a).balance;
+    let balance_b_before = state.get_account_by_id(fixture.lee_account_b).balance;
+    let balance_a_after_deposit = balance_a_before
+        .checked_sub(STAKE_AMOUNT)
+        .context("Sequencer A must be able to fund its stake")?;
+    let balance_b_after_deposit = balance_b_before
+        .checked_sub(STAKE_AMOUNT)
+        .context("Sequencer B must be able to fund its stake")?;
+    let balance_b_after_forfeit = balance_b_before
+        .checked_add(STAKE_AMOUNT)
+        .context("Sequencer B's compensated balance must not overflow")?;
+    let total_stake = STAKE_AMOUNT
+        .checked_mul(2)
+        .context("the combined stake must not overflow")?;
+
+    apply_lee_tx(
+        &mut state,
+        &vault_deposit(
+            fixture.lee_account_a,
+            &fixture.lee_key_a,
+            fixture.bond_enforcer,
+            0,
+            STAKE_AMOUNT,
+        )?,
+        1,
+    )?;
+    apply_lee_tx(
+        &mut state,
+        &vault_deposit(
+            fixture.lee_account_b,
+            &fixture.lee_key_b,
+            fixture.bond_enforcer,
+            0,
+            STAKE_AMOUNT,
+        )?,
+        2,
+    )?;
+
+    ensure!(state.get_account_by_id(fixture.lee_account_a).balance == balance_a_after_deposit);
+    ensure!(state.get_account_by_id(fixture.lee_account_b).balance == balance_b_after_deposit);
+    ensure!(state.get_account_by_id(vault_id).balance == total_stake);
+
+    let unauthorized = vault_claim(fixture.bond_enforcer, &fixture.lee_key_a, 0, total_stake)?;
+    ensure!(
+        state
+            .transition_from_public_transaction(&unauthorized, 3, 3)
+            .is_err(),
+        "a sequencer must not be able to claim the external enforcer's vault"
+    );
+    ensure!(state.get_account_by_id(vault_id).balance == total_stake);
+
+    apply_lee_tx(
+        &mut state,
+        &vault_claim(
+            fixture.bond_enforcer,
+            &fixture.bond_enforcer_key,
+            0,
+            total_stake,
+        )?,
+        4,
+    )?;
+    apply_lee_tx(
+        &mut state,
+        &native_transfer(
+            fixture.bond_enforcer,
+            &fixture.bond_enforcer_key,
+            fixture.lee_account_b,
+            1,
+            total_stake,
+        )?,
+        5,
+    )?;
+
+    ensure!(state.get_account_by_id(vault_id).balance == 0);
+    ensure!(state.get_account_by_id(fixture.bond_enforcer).balance == 0);
+    ensure!(state.get_account_by_id(fixture.lee_account_a).balance == balance_a_after_deposit);
+    ensure!(state.get_account_by_id(fixture.lee_account_b).balance == balance_b_after_forfeit);
+
+    println!("  A and B each deposited {STAKE_AMOUNT} native units from signed public accounts");
+    println!("  The LEZ vault rejected A's unauthorized claim");
+    println!("  External resolver paid both stakes to B after A's attributed abort");
+    println!("  PASS: A lost 1000; B gained 1000; escrow and resolver ended at zero");
+    Ok(())
+}
+
+fn vault_deposit(
+    sender: AccountId,
+    signing_key: &PrivateKey,
+    enforcer: AccountId,
+    nonce: u128,
+    amount: u128,
+) -> Result<PublicTransaction> {
+    let vault_id = vault_core::compute_vault_account_id(programs::vault().id(), enforcer);
+    signed_lee_tx(
+        programs::vault().id(),
+        vec![sender, vault_id],
+        nonce,
+        vault_core::Instruction::Transfer {
+            recipient_id: enforcer,
+            amount,
+        },
+        signing_key,
+    )
+}
+
+fn vault_claim(
+    enforcer: AccountId,
+    signing_key: &PrivateKey,
+    nonce: u128,
+    amount: u128,
+) -> Result<PublicTransaction> {
+    let vault_id = vault_core::compute_vault_account_id(programs::vault().id(), enforcer);
+    signed_lee_tx(
+        programs::vault().id(),
+        vec![enforcer, vault_id],
+        nonce,
+        vault_core::Instruction::Claim { amount },
+        signing_key,
+    )
+}
+
+fn native_transfer(
+    sender: AccountId,
+    signing_key: &PrivateKey,
+    recipient: AccountId,
+    nonce: u128,
+    amount: u128,
+) -> Result<PublicTransaction> {
+    signed_lee_tx(
+        programs::authenticated_transfer().id(),
+        vec![sender, recipient],
+        nonce,
+        authenticated_transfer_core::Instruction::Transfer { amount },
+        signing_key,
+    )
+}
+
+fn signed_lee_tx<I: serde::Serialize>(
+    program_id: lee::ProgramId,
+    account_ids: Vec<AccountId>,
+    nonce: u128,
+    instruction: I,
+    signing_key: &PrivateKey,
+) -> Result<PublicTransaction> {
+    let message = public_transaction::Message::try_new(
+        program_id,
+        account_ids,
+        vec![nonce.into()],
+        instruction,
+    )?;
+    let witness = public_transaction::WitnessSet::for_message(&message, &[signing_key]);
+    Ok(PublicTransaction::new(message, witness))
+}
+
+fn apply_lee_tx(state: &mut V03State, tx: &PublicTransaction, block_id: u64) -> Result<()> {
+    state
+        .transition_from_public_transaction(tx, block_id, block_id)
+        .map_err(|error| anyhow::anyhow!("LEE rejected bond transaction: {error}"))
+}
+
 fn heading(number: u8, title: &str) {
-    println!("[{number}/4] {title}");
+    println!("[{number}/5] {title}");
 }

--- a/tools/cacp_demo/src/main.rs
+++ b/tools/cacp_demo/src/main.rs
@@ -1,0 +1,238 @@
+#![allow(
+    clippy::print_stdout,
+    reason = "this presentation binary intentionally reports each checked scenario"
+)]
+
+use anyhow::{Context as _, Result, ensure};
+use cross_zone::cacp::{
+    BedrockError, BedrockModel, ChannelParent, CounterpartySession, CrossZoneIntent,
+    InitiatorSession, InscribeIntent, Phase, SubmissionResult, SubmittedBy, TimeoutOutcome,
+    TwoZoneTopology, ZoneSequencer,
+};
+use logos_blockchain_core::mantle::{
+    ops::{
+        Op,
+        channel::{ChannelId, MsgId},
+    },
+    traits::Hashable as _,
+};
+use logos_blockchain_key_management_system_service::keys::Ed25519Key;
+
+struct Fixture {
+    key_a: Ed25519Key,
+    key_b: Ed25519Key,
+    intent: CrossZoneIntent,
+    topology: TwoZoneTopology,
+    parents: [ChannelParent; 2],
+}
+
+fn main() -> Result<()> {
+    println!("CACP reference-model demo");
+    println!("Scope: 1 Bedrock | 2 zones | 1 sequencer per zone | 2 ChannelInscribe ops");
+    println!("Note: inscriptions carry data; they do not enforce stake custody or forfeiture.\n");
+
+    let fixture = fixture()?;
+    happy_path(&fixture)?;
+    counterparty_fallback(&fixture)?;
+    safe_pre_phase_three_abort(&fixture)?;
+    stale_parent_atomic_rejection(&fixture)?;
+
+    println!("\nALL 4 CACP SCENARIOS PASSED");
+    Ok(())
+}
+
+fn fixture() -> Result<Fixture> {
+    let key_a = Ed25519Key::from_bytes(&[0xA1; 32]);
+    let key_b = Ed25519Key::from_bytes(&[0xB2; 32]);
+    let channel_a = ChannelId::from([1; 32]);
+    let channel_b = ChannelId::from([2; 32]);
+    let intent = CrossZoneIntent::new(
+        [
+            InscribeIntent {
+                channel_id: channel_a,
+                payload: b"zone-a inscription".to_vec(),
+            },
+            InscribeIntent {
+                channel_id: channel_b,
+                payload: b"zone-b inscription".to_vec(),
+            },
+        ],
+        7,
+    )?;
+    let topology = TwoZoneTopology::new(
+        ZoneSequencer {
+            channel_id: channel_a,
+            public_key: key_a.public_key(),
+        },
+        ZoneSequencer {
+            channel_id: channel_b,
+            public_key: key_b.public_key(),
+        },
+        &intent,
+    )?;
+    let parents = [
+        ChannelParent {
+            channel_id: channel_a,
+            parent: MsgId::from([3; 32]),
+        },
+        ChannelParent {
+            channel_id: channel_b,
+            parent: MsgId::from([4; 32]),
+        },
+    ];
+    Ok(Fixture {
+        key_a,
+        key_b,
+        intent,
+        topology,
+        parents,
+    })
+}
+
+fn phase_three(fixture: &Fixture) -> Result<(InitiatorSession, CounterpartySession)> {
+    let mut initiator = InitiatorSession::new(
+        fixture.topology.clone(),
+        fixture.intent.clone(),
+        fixture.parents,
+    )?;
+    let mut counterparty = CounterpartySession::new(
+        fixture.topology.clone(),
+        fixture.intent.clone(),
+        fixture.parents,
+    )?;
+    let accept = counterparty.receive_propose(&initiator.propose(), &fixture.key_b)?;
+    let finalize = initiator.receive_accept(accept, &fixture.key_a)?;
+    counterparty.receive_finalize(finalize)?;
+
+    ensure!(initiator.phase() == Phase::SignaturesExchanged);
+    ensure!(counterparty.phase() == Phase::SignaturesExchanged);
+    Ok((initiator, counterparty))
+}
+
+fn happy_path(fixture: &Fixture) -> Result<()> {
+    heading(1, "happy path");
+    let (mut initiator, mut counterparty) = phase_three(fixture)?;
+    let signed_tx = initiator
+        .signed_tx()
+        .context("initiator should hold the jointly signed transaction")?;
+    let counterparty_hash = counterparty
+        .signed_tx()
+        .context("counterparty should hold the jointly signed transaction")?
+        .hash();
+    ensure!(signed_tx.hash() == counterparty_hash);
+    ensure!(signed_tx.mantle_tx().ops().len() == 2);
+    ensure!(
+        signed_tx
+            .mantle_tx()
+            .ops()
+            .iter()
+            .all(|op| matches!(op, Op::ChannelInscribe(_)))
+    );
+
+    let mut bedrock = BedrockModel::new(fixture.parents);
+    let result = bedrock.submit(signed_tx, SubmittedBy::Initiator)?;
+    let SubmissionResult::Included(tx_hash) = result else {
+        anyhow::bail!("the first submission must be included");
+    };
+    ensure!(bedrock.submitted_by(tx_hash) == Some(SubmittedBy::Initiator));
+    initiator.mark_submitted()?;
+    counterparty.mark_submitted()?;
+
+    println!("  PROPOSE -> ACCEPT -> FINALIZE -> submit by Sequencer A");
+    println!("  PASS: Bedrock included one joint tx with exactly two ChannelInscribe ops");
+    Ok(())
+}
+
+fn counterparty_fallback(fixture: &Fixture) -> Result<()> {
+    heading(
+        2,
+        "Phase 3 reached; Sequencer B performs fallback submission",
+    );
+    let (mut initiator, mut counterparty) = phase_three(fixture)?;
+    let TimeoutOutcome::FallbackSubmission(signed_tx) = counterparty.on_timeout() else {
+        anyhow::bail!("Sequencer B must retain fallback submission rights after Phase 3");
+    };
+
+    let mut bedrock = BedrockModel::new(fixture.parents);
+    let SubmissionResult::Included(tx_hash) =
+        bedrock.submit(&signed_tx, SubmittedBy::CounterpartyFallback)?
+    else {
+        anyhow::bail!("Sequencer B's first submission must be included");
+    };
+    ensure!(
+        bedrock.submitted_by(tx_hash) == Some(SubmittedBy::CounterpartyFallback),
+        "Bedrock must attribute inclusion to the fallback submitter"
+    );
+    let duplicate = bedrock.submit(&signed_tx, SubmittedBy::Initiator)?;
+    ensure!(duplicate == SubmissionResult::AlreadyIncluded(tx_hash));
+    counterparty.mark_submitted()?;
+    initiator.mark_submitted()?;
+
+    println!("  Sequencer A stalls after FINALIZE; B submits the identical signed tx");
+    println!("  PASS: fallback included once; a later duplicate is idempotent");
+    Ok(())
+}
+
+fn safe_pre_phase_three_abort(fixture: &Fixture) -> Result<()> {
+    heading(3, "safe abort before Phase 3");
+    let mut initiator = InitiatorSession::new(
+        fixture.topology.clone(),
+        fixture.intent.clone(),
+        fixture.parents,
+    )?;
+    ensure!(initiator.on_timeout() == TimeoutOutcome::Aborted);
+    ensure!(initiator.phase() == Phase::Aborted);
+    ensure!(initiator.signed_tx().is_none());
+
+    let proposer = InitiatorSession::new(
+        fixture.topology.clone(),
+        fixture.intent.clone(),
+        fixture.parents,
+    )?;
+    let mut counterparty = CounterpartySession::new(
+        fixture.topology.clone(),
+        fixture.intent.clone(),
+        fixture.parents,
+    )?;
+    counterparty.receive_propose(&proposer.propose(), &fixture.key_b)?;
+    ensure!(counterparty.phase() == Phase::WaitingForFinalize);
+    ensure!(counterparty.on_timeout() == TimeoutOutcome::Aborted);
+    ensure!(counterparty.signed_tx().is_none());
+
+    println!("  Tested timeout before ACCEPT and timeout while waiting for FINALIZE");
+    println!("  PASS: no fully signed transaction exists, so no channel tip can advance");
+    Ok(())
+}
+
+fn stale_parent_atomic_rejection(fixture: &Fixture) -> Result<()> {
+    heading(4, "stale parent causes atomic rejection");
+    let (initiator, _counterparty) = phase_three(fixture)?;
+    let signed_tx = initiator
+        .signed_tx()
+        .context("Phase 3 should produce a jointly signed transaction")?;
+    let current_parents = [
+        ChannelParent {
+            channel_id: fixture.parents[0].channel_id,
+            parent: MsgId::from([0xCC; 32]),
+        },
+        fixture.parents[1],
+    ];
+    let mut bedrock = BedrockModel::new(current_parents);
+    let before_a = bedrock.tip(fixture.parents[0].channel_id);
+    let before_b = bedrock.tip(fixture.parents[1].channel_id);
+
+    let error = bedrock
+        .submit(signed_tx, SubmittedBy::Initiator)
+        .expect_err("the stale parent must reject the whole transaction");
+    ensure!(error == BedrockError::StaleParent);
+    ensure!(bedrock.tip(fixture.parents[0].channel_id) == before_a);
+    ensure!(bedrock.tip(fixture.parents[1].channel_id) == before_b);
+
+    println!("  Zone A parent is stale when the joint tx reaches Bedrock");
+    println!("  PASS: both inscriptions rejected; neither channel tip changed");
+    Ok(())
+}
+
+fn heading(number: u8, title: &str) {
+    println!("[{number}/4] {title}");
+}


### PR DESCRIPTION
## 🎯 Purpose

Add a minimal CACP protocol demonstration for two sequencers coordinating one joint Mantle transaction across two zones, plus a separately executed bond backed by real LEZ public-account balances.

The joint Mantle transaction still contains exactly two `ChannelInscribe` operations. It demonstrates the happy path, counterparty fallback submission after Phase 3, safe abort before Phase 3, atomic stale-parent rejection, and an externally attributed costly abort with an actual stake payout.

## ⚙️ Approach

- [x] Add a two-sequencer CACP state machine.
- [x] Restrict the joint Mantle transaction to two `ChannelInscribe` operations.
- [x] Add initiator and counterparty fallback submission paths.
- [x] Add pre-Phase 3 abort and stale-parent atomic rejection.
- [x] Bind the external enforcer public account and stake amount into the CACP proposal ID.
- [x] Execute two signed LEZ public-account deposits through `vault` and `authenticated_transfer`.
- [x] Prove a sequencer cannot claim the resolver's vault.
- [x] Execute a real payout in which A loses 1,000 native units and B gains 1,000.
- [x] Add `tools/cacp_demo` and `just demo-cacp`.

## 🧪 How to Test

- `cargo fmt -p cross_zone -p cacp_demo`
- `cargo test -p cross_zone --lib` — 7 passed
- `cargo clippy -p cross_zone -p cacp_demo --all-targets -- -D warnings`
- `just demo-cacp` — all 5 scenarios passed

## 🔐 Execution boundary

L1 inscriptions remain data and do not execute custody rules.

Stake custody and payout are separate LEE transactions. The demo uses funded public accounts, the existing `vault` program, and `authenticated_transfer`, so the balance decreases, escrow balance, authorization rejection, and final payout are enforced by LEZ state-transition rules.

The current resolver is explicitly trusted to attribute the abort and choose the payout. Replacing that trust with challenge/response adjudication and authenticated Bedrock-inclusion evidence remains future work.

## 📋 PR Completion Checklist

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
