### PR TITLE
feat(lee): add core types for program upgrades

### DIFF
--- a/lee/state_machine/core/src/encoding.rs
+++ b/lee/state_machine/core/src/encoding.rs
@@ -11,7 +11,7 @@ use crate::encryption::{EphemeralPublicKey, ML_KEM_768_CIPHERTEXT_LEN};
 #[cfg(feature = "host")]
 use crate::error::LeeCoreError;
 use crate::{
-    Commitment, NullifierPublicKey,
+    Commitment, NullifierPublicKey, ProgramCommitment,
     account::{Account, AccountId},
     encryption::Ciphertext,
 };
@@ -92,6 +92,19 @@ impl NullifierPublicKey {
     #[must_use]
     pub const fn to_byte_array(&self) -> [u8; 32] {
         self.0
+    }
+}
+
+impl ProgramCommitment {
+    #[must_use]
+    pub const fn to_byte_array(&self) -> [u8; 32] {
+        self.0
+    }
+
+    #[cfg(feature = "host")]
+    #[must_use]
+    pub const fn from_byte_array(bytes: [u8; 32]) -> Self {
+        Self(bytes)
     }
 }
 

--- a/lee/state_machine/core/src/lib.rs
+++ b/lee/state_machine/core/src/lib.rs
@@ -19,6 +19,7 @@ pub use nullifier::{
     AuthorizationSecretKey, Identifier, Nullifier, NullifierPublicKey, NullifierSecretKey,
 };
 pub use program::PrivateAccountKind;
+pub use program_commitment::ProgramCommitment;
 
 pub mod account;
 mod circuit_io;
@@ -27,6 +28,7 @@ mod encoding;
 pub mod encryption;
 mod nullifier;
 pub mod program;
+mod program_commitment;
 
 #[cfg(feature = "host")]
 pub mod error;

--- a/lee/state_machine/core/src/program_commitment.rs
+++ b/lee/state_machine/core/src/program_commitment.rs
@@ -1,0 +1,56 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+use crate::program::ProgramId;
+
+#[derive(Copy, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(
+    any(feature = "host", test),
+    derive(Debug, PartialEq, Eq, Hash, PartialOrd, Ord)
+)]
+pub struct ProgramCommitment(pub(super) [u8; 32]);
+
+impl ProgramCommitment {
+    #[must_use]
+    pub fn new(program_id: ProgramId) -> Self {
+        let mut bytes = Vec::with_capacity(32);
+        for word in program_id {
+            bytes.extend_from_slice(&word.to_le_bytes());
+        }
+        Self(bytes.try_into().unwrap())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ProgramCommitment;
+
+    #[test]
+    fn new_is_deterministic() {
+        let program_id: crate::program::ProgramId = [1, 2, 3, 4, 5, 6, 7, 8];
+        assert_eq!(
+            ProgramCommitment::new(program_id),
+            ProgramCommitment::new(program_id)
+        );
+    }
+
+    #[test]
+    fn new_differs_for_different_ids() {
+        let a: crate::program::ProgramId = [1, 0, 0, 0, 0, 0, 0, 0];
+        let b: crate::program::ProgramId = [2, 0, 0, 0, 0, 0, 0, 0];
+        assert_ne!(ProgramCommitment::new(a), ProgramCommitment::new(b));
+    }
+
+    #[test]
+    fn new_matches_le_byte_encoding() {
+        let program_id: crate::program::ProgramId = [1, 2, 3, 4, 5, 6, 7, 8];
+        let mut expected = Vec::with_capacity(32);
+        for word in program_id {
+            expected.extend_from_slice(&word.to_le_bytes());
+        }
+        assert_eq!(
+            ProgramCommitment::new(program_id).to_byte_array(),
+            expected.as_slice()
+        );
+    }
+}

--- a/lee/state_machine/src/state/mod.rs
+++ b/lee/state_machine/src/state/mod.rs
@@ -67,12 +67,6 @@ impl CommitmentSet {
     }
 }
 
-/// Merkle tree of `ProgramCommitment`s, appended to on every program-deployment transaction.
-/// Phase 1 of the program-upgrade proposal (`upgrade_proposal.md`) — see `ProgramCommitment`'s
-/// own doc comment for the bootstrap definition currently in use. Mirrors `CommitmentSet`'s
-/// shape; doesn't need a `root_history` the way `CommitmentSet` does, since nothing currently
-/// checks program-commitment proofs against a historical root (that lands with the
-/// privacy-preserving circuit integration in Phase 1 PR 2).
 #[cfg_attr(test, derive(Debug))]
 #[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct ProgramCommitmentDigest {
@@ -94,10 +88,6 @@ impl ProgramCommitmentDigest {
             .map(|path| (index, path))
     }
 
-    /// All committed `ProgramCommitment` values, in unspecified (`HashMap` iteration) order.
-    /// For an order-independent view — e.g. for hashing into `genesis_fingerprint` — sort the
-    /// result first; the Merkle root from `digest()` is insertion-order-dependent and not
-    /// suitable for that on its own.
     pub(crate) fn commitments(&self) -> impl Iterator<Item = &ProgramCommitment> {
         self.commitments.keys()
     }
@@ -118,6 +108,67 @@ impl ProgramCommitmentDigest {
             merkle_tree: MerkleTree::with_capacity(capacity),
             commitments: HashMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+mod program_commitment_digest_tests {
+    use super::{ProgramCommitment, ProgramCommitmentDigest, ProgramId};
+
+    fn commitment(id: u32) -> ProgramCommitment {
+        let program_id: ProgramId = [id, 0, 0, 0, 0, 0, 0, 0];
+        ProgramCommitment::new(program_id)
+    }
+
+    #[test]
+    fn incremental_extend_matches_single_extend() {
+        let mut a = ProgramCommitmentDigest::with_capacity(8);
+        a.extend(&[commitment(1), commitment(2), commitment(3)]);
+
+        let mut b = ProgramCommitmentDigest::with_capacity(8);
+        b.extend(&[commitment(1)]);
+        b.extend(&[commitment(2)]);
+        b.extend(&[commitment(3)]);
+
+        assert_eq!(a.digest(), b.digest());
+    }
+
+    /// `digest()` is a Merkle root over insertion order, not a set commitment — see the
+    /// type's doc comment. Same commitments in a different order must therefore produce a
+    /// different root; callers needing an order-independent view use `commitments()` instead.
+    #[test]
+    fn same_commitments_in_different_order_yield_different_roots() {
+        let mut a = ProgramCommitmentDigest::with_capacity(8);
+        a.extend(&[commitment(1), commitment(2), commitment(3)]);
+
+        let mut b = ProgramCommitmentDigest::with_capacity(8);
+        b.extend(&[commitment(3), commitment(2), commitment(1)]);
+
+        assert_ne!(a.digest(), b.digest());
+    }
+
+    /// Unlike `digest()`, `commitments()` is the order-independent view: the same
+    /// commitments inserted in a different order still yield the same *set*.
+    #[test]
+    fn same_commitments_in_different_order_yield_same_commitment_set() {
+        let mut a = ProgramCommitmentDigest::with_capacity(8);
+        a.extend(&[commitment(1), commitment(2), commitment(3)]);
+
+        let mut b = ProgramCommitmentDigest::with_capacity(8);
+        b.extend(&[commitment(3), commitment(2), commitment(1)]);
+
+        let a_set: std::collections::HashSet<_> = a.commitments().copied().collect();
+        let b_set: std::collections::HashSet<_> = b.commitments().copied().collect();
+
+        assert_eq!(a_set, b_set);
+    }
+
+    #[test]
+    fn empty_digest_is_deterministic() {
+        let a = ProgramCommitmentDigest::with_capacity(8);
+        let b = ProgramCommitmentDigest::with_capacity(8);
+
+        assert_eq!(a.digest(), b.digest());
     }
 }
 

--- a/lee/state_machine/src/state/mod.rs
+++ b/lee/state_machine/src/state/mod.rs
@@ -3,7 +3,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use borsh::{BorshDeserialize, BorshSerialize};
 use lee_core::{
     BlockId, Commitment, CommitmentSetDigest, DUMMY_COMMITMENT, MembershipProof, Nullifier,
-    Timestamp,
+    ProgramCommitment, Timestamp,
     account::{Account, AccountId},
     program::ProgramId,
 };
@@ -67,6 +67,60 @@ impl CommitmentSet {
     }
 }
 
+/// Merkle tree of `ProgramCommitment`s, appended to on every program-deployment transaction.
+/// Phase 1 of the program-upgrade proposal (`upgrade_proposal.md`) — see `ProgramCommitment`'s
+/// own doc comment for the bootstrap definition currently in use. Mirrors `CommitmentSet`'s
+/// shape; doesn't need a `root_history` the way `CommitmentSet` does, since nothing currently
+/// checks program-commitment proofs against a historical root (that lands with the
+/// privacy-preserving circuit integration in Phase 1 PR 2).
+#[cfg_attr(test, derive(Debug))]
+#[derive(Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct ProgramCommitmentDigest {
+    merkle_tree: MerkleTree,
+    commitments: HashMap<ProgramCommitment, usize>,
+}
+
+impl ProgramCommitmentDigest {
+    pub(crate) fn digest(&self) -> [u8; 32] {
+        self.merkle_tree.root()
+    }
+
+    /// Queries the `ProgramCommitmentDigest` for a membership proof of a program commitment.
+    pub fn get_proof_for(&self, commitment: &ProgramCommitment) -> Option<MembershipProof> {
+        let index = *self.commitments.get(commitment)?;
+
+        self.merkle_tree
+            .get_authentication_path_for(index)
+            .map(|path| (index, path))
+    }
+
+    /// All committed `ProgramCommitment` values, in unspecified (`HashMap` iteration) order.
+    /// For an order-independent view — e.g. for hashing into `genesis_fingerprint` — sort the
+    /// result first; the Merkle root from `digest()` is insertion-order-dependent and not
+    /// suitable for that on its own.
+    pub(crate) fn commitments(&self) -> impl Iterator<Item = &ProgramCommitment> {
+        self.commitments.keys()
+    }
+
+    /// Inserts a list of program commitments to the `ProgramCommitmentDigest`.
+    pub(crate) fn extend(&mut self, commitments: &[ProgramCommitment]) {
+        for commitment in commitments.iter().copied() {
+            let index = self.merkle_tree.insert(commitment.to_byte_array());
+            self.commitments.insert(commitment, index);
+        }
+    }
+
+    /// Initializes an empty `ProgramCommitmentDigest` with a given capacity.
+    /// If the capacity is not a `power_of_two`, then capacity is taken
+    /// to be the next `power_of_two`.
+    pub(crate) fn with_capacity(capacity: usize) -> Self {
+        Self {
+            merkle_tree: MerkleTree::with_capacity(capacity),
+            commitments: HashMap::new(),
+        }
+    }
+}
+
 #[cfg_attr(test, derive(Debug))]
 #[derive(Clone, PartialEq, Eq)]
 struct NullifierSet(BTreeSet<Nullifier>);
@@ -115,6 +169,7 @@ pub struct V03State {
     public_state: HashMap<AccountId, Account>,
     private_state: (CommitmentSet, NullifierSet),
     programs: HashMap<ProgramId, Program>,
+    program_commitments: ProgramCommitmentDigest,
 }
 
 impl Default for V03State {
@@ -128,6 +183,7 @@ impl Default for V03State {
             public_state: HashMap::default(),
             private_state,
             programs: HashMap::default(),
+            program_commitments: ProgramCommitmentDigest::with_capacity(32),
         }
     }
 }
@@ -196,7 +252,14 @@ impl V03State {
     }
 
     pub(crate) fn insert_program(&mut self, program: Program) {
+        let program_id = program.id();
         self.programs.insert(program.id(), program);
+        self.append_new_program_commitment(program_id);
+    }
+
+    pub(crate) fn append_new_program_commitment(&mut self, program_id: ProgramId) {
+        let commitment = ProgramCommitment::new(program_id);
+        self.program_commitments.extend(&[commitment]);
     }
 
     pub fn apply_state_diff(&mut self, diff: ValidatedStateDiff) {
@@ -290,8 +353,22 @@ impl V03State {
         self.private_state.0.digest()
     }
 
+    #[must_use]
+    pub fn get_proof_for_program_commitment(
+        &self,
+        commitment: &ProgramCommitment,
+    ) -> Option<MembershipProof> {
+        self.program_commitments.get_proof_for(commitment)
+    }
+
+    #[must_use]
+    pub fn program_commitment_digest(&self) -> [u8; 32] {
+        self.program_commitments.digest()
+    }
+
     /// Order-independent fingerprint of the genesis-relevant state: the public
-    /// account set, the deployed program set, and the commitment-set digest.
+    /// account set, the deployed program set, the deployed programs' commitments, and the
+    /// private commitment-set digest.
     ///
     /// The sequencer and the indexer build the directly-seeded part of genesis
     /// (base builtins plus any directly-seeded accounts) separately from their own
@@ -309,6 +386,7 @@ impl V03State {
             public_state,
             private_state,
             programs,
+            program_commitments,
         } = self;
 
         let mut accounts: Vec<(&AccountId, &Account)> = public_state.iter().collect();
@@ -317,8 +395,21 @@ impl V03State {
         let mut program_ids: Vec<ProgramId> = programs.keys().copied().collect();
         program_ids.sort_unstable();
 
+        // `program_commitments.digest()` is a Merkle root and therefore
+        // insertion-order-dependent — hashing it directly here would make this
+        // supposedly order-independent fingerprint depend on program *registration*
+        // order, not just the resulting set. Sort the individual commitment values
+        // instead, the same way `program_ids` is sorted above.
+        let mut program_commitment_bytes: Vec<[u8; 32]> = program_commitments
+            .commitments()
+            .map(ProgramCommitment::to_byte_array)
+            .collect();
+        program_commitment_bytes.sort_unstable();
+
         let account_count = u64::try_from(accounts.len()).expect("account count fits in u64");
         let program_count = u64::try_from(program_ids.len()).expect("program count fits in u64");
+        let program_commitment_count = u64::try_from(program_commitment_bytes.len())
+            .expect("program commitment count fits in u64");
 
         let mut hasher = Sha256::new();
         hasher.update(account_count.to_le_bytes());
@@ -334,6 +425,10 @@ impl V03State {
             for word in id {
                 hasher.update(word.to_le_bytes());
             }
+        }
+        hasher.update(program_commitment_count.to_le_bytes());
+        for commitment_bytes in program_commitment_bytes {
+            hasher.update(commitment_bytes);
         }
         hasher.update(private_state.0.digest());
 

--- a/lee/state_machine/src/state/tests/genesis.rs
+++ b/lee/state_machine/src/state/tests/genesis.rs
@@ -75,6 +75,50 @@ fn insert_program() {
 }
 
 #[test]
+fn insert_program_makes_program_commitment_provable() {
+    let mut state = V03State::new();
+    let program_to_insert = crate::test_methods::simple_balance_transfer();
+    let commitment = ProgramCommitment::new(program_to_insert.id());
+    assert!(
+        state
+            .get_proof_for_program_commitment(&commitment)
+            .is_none()
+    );
+
+    state.insert_program(program_to_insert);
+
+    assert!(
+        state
+            .get_proof_for_program_commitment(&commitment)
+            .is_some(),
+        "the inserted program's commitment should be provable"
+    );
+}
+
+#[test]
+fn program_deployment_transaction_makes_program_commitment_provable() {
+    let mut state = V03State::new();
+    let bytecode = crate::test_methods::simple_balance_transfer()
+        .elf()
+        .to_vec();
+    let message = crate::program_deployment_transaction::Message::new(bytecode);
+    let tx = crate::program_deployment_transaction::ProgramDeploymentTransaction::new(message);
+
+    state
+        .transition_from_program_deployment_transaction(&tx)
+        .expect("a fresh program deployment should succeed");
+
+    let program_id = crate::test_methods::simple_balance_transfer().id();
+    let commitment = ProgramCommitment::new(program_id);
+    assert!(
+        state
+            .get_proof_for_program_commitment(&commitment)
+            .is_some(),
+        "the deployed program's commitment should be provable"
+    );
+}
+
+#[test]
 fn get_account_by_account_id_non_default_account() {
     let key = PrivateKey::try_new([1; 32]).unwrap();
     let account_id = AccountId::from(&PublicKey::new_from_private_key(&key));

--- a/lee/state_machine/src/state/tests/mod.rs
+++ b/lee/state_machine/src/state/tests/mod.rs
@@ -8,8 +8,8 @@ use std::collections::HashMap;
 
 use lee_core::{
     AuthorizationSecretKey, BlockId, Commitment, DUMMY_COMMITMENT_HASH, InputAccountIdentity,
-    Nullifier, NullifierPublicKey, NullifierSecretKey, NullifierWitness, PrivateWitness, Timestamp,
-    WitnessKind,
+    Nullifier, NullifierPublicKey, NullifierSecretKey, NullifierWitness, PrivateWitness,
+    ProgramCommitment, Timestamp, WitnessKind,
     account::{Account, AccountId, AccountWithMetadata, Nonce, data::Data},
     encryption::ViewingPublicKey,
     program::{


### PR DESCRIPTION
## 🎯 Purpose

This PR introduces datatypes that will be used for [Program Upgrade](https://hackmd.io/@-CvgMMUrRhC2aJOVst_GAw/BJ76wCQ8Gg): `ProgramCommitment` and `ProgramCommitmentDigest`. This PR introduces these datatypes, but does not incorporate them within LEE logic. Logic incorporation will be done over the course of multiple (future) PRs.

## ⚙️ Approach

- [X] `ProgramCommitment` with `new` computing `program_id`.
- [X] `ProgramCommitmentDigest` Merkle tree and a list (HashMap) of `ProgramCommitments`.

## 🧪 How to Test

Unit tests for `ProgramCommitment` and `ProgramCommitmentDigest`:
- `program_deployment_transaction_makes_program_commitment_provable`
- `insert_program_makes_program_commitment_provable`
- `incremental_extend_matches_single_extend`
- `same_commitments_in_different_order_yield_different_roots`
- `same_commitments_in_different_order_yield_same_commitment_set`
- `empty_digest_is_deterministic`

## 🔗 Dependencies

N/A

TO COMPLETE IF APPLICABLE

## 🔜 Future Work

Future PRs incorporate the `ProgramCommitment` and `ProgramCommitmentDigest` logic in transactions and privacy preserving circuit based on [Program updates in LEZ proposal](https://hackmd.io/@-CvgMMUrRhC2aJOVst_GAw/BJ76wCQ8Gg)

TO COMPLETE IF APPLICABLE

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [X] Complete PR description
- [X] Implement the core functionality
- [X] Add/update tests
- [X] Add/update documentation and inline comments
