### PR TITLE
fix(cross-zone): one peer-block acceptance policy for watcher and verifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1979,7 +1979,9 @@ name = "cross_zone"
 version = "0.1.0"
 dependencies = [
  "bridge_lock_core",
+ "common",
  "cross_zone_inbox_core",
+ "hex",
  "lee",
  "lee_core",
  "ping_core",

--- a/lez/common/src/block.rs
+++ b/lez/common/src/block.rs
@@ -22,6 +22,18 @@ impl From<&Block> for BlockMeta {
     }
 }
 
+/// The last peer block accepted onto a cross-zone peer chain, and the link the
+/// next one has to carry.
+///
+/// `block_hash` is the recomputed hash, not `header.hash` as read: the
+/// signature does not cover that field, so a signed block may carry a bogus one
+/// and break the link against the peer's next honest block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
+pub struct PeerChainTip {
+    pub block_id: u64,
+    pub block_hash: HashType,
+}
+
 #[derive(Debug, Clone)]
 /// Our own hasher.
 /// Currently it is SHA256 hasher wrapper. May change in a future.

--- a/lez/cross_zone/Cargo.toml
+++ b/lez/cross_zone/Cargo.toml
@@ -7,13 +7,19 @@ license = { workspace = true }
 [lints]
 workspace = true
 
+[features]
+# Chain-builder helpers shared by the watcher's and verifier's tests.
+test-utils = []
+
 [dependencies]
 lee.workspace = true
 lee_core.workspace = true
 programs.workspace = true
+common.workspace = true
 cross_zone_inbox_core.workspace = true
 bridge_lock_core.workspace = true
 ping_core.workspace = true
 wrapped_token_core.workspace = true
 serde.workspace = true
 risc0-zkvm.workspace = true
+hex.workspace = true

--- a/lez/cross_zone/src/acceptance.rs
+++ b/lez/cross_zone/src/acceptance.rs
@@ -1,0 +1,472 @@
+//! The one peer-block acceptance policy.
+//!
+//! The sequencer's watcher and the indexer's verifier both admit peer blocks
+//! through here, so they cannot disagree about which block holds an id: a
+//! disagreement makes the verifier re-derive a delivery against a block the
+//! watcher never delivered from, and ingestion halts.
+
+use std::fmt::{self, Display, Formatter};
+
+use common::{
+    HashType,
+    block::{Block, PeerChainTip},
+};
+use cross_zone_inbox_core::ZoneId;
+use lee::{GENESIS_BLOCK_ID, PublicKey};
+
+/// Consecutive passes a reader spends stuck on one slot before it says so as
+/// something more than the per-pass failure. It never reads past the slot.
+///
+/// The cadence bounds log volume only: at one pass per poll interval, 5 passes
+/// is roughly seconds to tens of seconds depending on each side's interval.
+pub const STUCK_SLOT_ALERT_PASSES: u32 = 5;
+
+/// Where a screened peer block sits relative to the chain pinned by `tip`.
+#[derive(Debug, PartialEq, Eq)]
+pub enum Link {
+    /// The next block on the peer's chain, carrying its recomputed hash.
+    Next(HashType),
+    /// At or below the tip, so already accepted from. The ordinary shape of a
+    /// re-read slot. `equivocates` is set when the block claims the tip's own
+    /// id under a different hash, so callers can say so; below the tip there is
+    /// no held hash to compare against and it is never set.
+    AlreadySeen { equivocates: bool },
+    /// Not on the chain the tip pins, so not acceptable. Callers read on: the
+    /// peer's own next block still links to the tip, and treating this as
+    /// terminal would hand the peer a way to stop its deliveries permanently.
+    OffChain(OffChain),
+}
+
+/// Why a block is not on the chain the tip pins.
+#[derive(Debug, PartialEq, Eq)]
+pub enum OffChain {
+    /// The next id off the tip, but linking to some other predecessor.
+    DoesNotLink {
+        block_id: u64,
+        tip_id: u64,
+        links_to: HashType,
+        expected: HashType,
+    },
+    /// Read with no stored tip, and not the peer's genesis. Anchoring on
+    /// whatever arrived first would let the peer pick the id, and burn every
+    /// replay key below it with one block.
+    NotTheGenesis { block_id: u64 },
+    /// An id above the next one on the chain.
+    SkipsAhead { block_id: u64, next: u64 },
+}
+
+impl Display for OffChain {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::DoesNotLink {
+                block_id,
+                tip_id,
+                links_to,
+                expected,
+            } => write!(
+                f,
+                "block {block_id} does not follow block {tip_id}: it links to {links_to} rather than {expected}"
+            ),
+            Self::NotTheGenesis { block_id } => write!(
+                f,
+                "block {block_id} is the first one read, but with no stored chain tip acceptance has to start at the peer's genesis block {GENESIS_BLOCK_ID}"
+            ),
+            Self::SkipsAhead { block_id, next } => write!(
+                f,
+                "block {block_id} skips past {next}, which is either a hole in what this node read or an id claimed ahead of the peer's chain"
+            ),
+        }
+    }
+}
+
+/// Why a peer block was refused before any chain placement.
+///
+/// The channel authorizes who may write, not what they may claim. The hash
+/// check is unconditional: the signature does not cover `header.hash`, and the
+/// chain link compares hashes, so an unchecked one lets a peer assert links it
+/// never built. The pinned key, checked only when one is configured, is what
+/// says the peer's own sequencer produced the block; it subsumes nothing here,
+/// since a correctly signed block may still carry a bogus hash.
+#[derive(Debug, PartialEq, Eq)]
+pub enum ScreenRefusal {
+    /// `header.hash` is not the hash of the block's contents.
+    HashMismatch {
+        block_id: u64,
+        declared: HashType,
+        recomputed: HashType,
+    },
+    /// The block is not signed by the pinned block-signing key.
+    KeyMismatch { block_id: u64 },
+}
+
+impl Display for ScreenRefusal {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match *self {
+            Self::HashMismatch {
+                block_id,
+                declared,
+                recomputed,
+            } => write!(
+                f,
+                "block {block_id} carries header hash {declared} but its contents hash to {recomputed}"
+            ),
+            Self::KeyMismatch { block_id } => write!(
+                f,
+                "block {block_id} is not signed by the pinned block-signing key"
+            ),
+        }
+    }
+}
+
+/// The pass-to-pass stall of one peer reader: the slot it is stuck on and how
+/// many consecutive passes it has spent there. Keyed by slot so a failure at a
+/// new slot does not inherit an older slot's count.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct StallState<S> {
+    stalled: Option<(S, u32)>,
+}
+
+impl<S> Default for StallState<S> {
+    fn default() -> Self {
+        Self { stalled: None }
+    }
+}
+
+impl<S: Copy + PartialEq + PartialOrd> StallState<S> {
+    /// Folds one pass in: `stuck_on` is the slot the pass ended inside, `None`
+    /// for a pass that ended cleanly. Returns the slot the reader is stuck on
+    /// and how long it has been stuck, so the caller can say so on the
+    /// [`alerts_at`] cadence.
+    ///
+    /// `read_to` is the read position after the pass, and is what tells a
+    /// stream that truncated early apart from one that genuinely drained: the
+    /// zone-sdk ends a stream on a fetch failure exactly as it does on catching
+    /// up, so without it a flaky peer endpoint resets the count for ever and a
+    /// reader stuck for hours never says so.
+    pub fn after_pass(&mut self, stuck_on: Option<S>, read_to: Option<S>) -> Option<(S, u32)> {
+        let Some(slot) = stuck_on else {
+            if self.passed_the_stall(read_to) {
+                self.stalled = None;
+            }
+            return None;
+        };
+        let attempts = match self.stalled {
+            Some((held, attempts)) if held == slot => attempts.saturating_add(1),
+            _ => 1,
+        };
+        self.stalled = Some((slot, attempts));
+        self.stalled
+    }
+
+    /// Whether the read position is now past whatever the reader was stuck on.
+    /// Vacuously true when it was not stuck.
+    fn passed_the_stall(self, read_to: Option<S>) -> bool {
+        self.stalled
+            .is_none_or(|(stuck_on, _)| read_to.is_some_and(|slot| slot >= stuck_on))
+    }
+}
+
+/// Whether a reader stuck for `attempts` passes should say so on this one.
+///
+/// Every [`STUCK_SLOT_ALERT_PASSES`], not on the crossing alone: a stall that
+/// never clears would otherwise be reported once and then look resolved for as
+/// long as it lasts. Not every pass, since that is one line per block time.
+#[must_use]
+pub const fn alerts_at(attempts: u32) -> bool {
+    attempts > 0 && attempts.is_multiple_of(STUCK_SLOT_ALERT_PASSES)
+}
+
+/// The one report both sides log for a differing block at an id the accepted
+/// chain already holds.
+#[must_use]
+pub fn equivocation_report(
+    peer_zone: &ZoneId,
+    block_id: u64,
+    holding: HashType,
+    refusing: HashType,
+) -> String {
+    format!(
+        "Peer zone {} equivocated at block {block_id}: holding {holding}, refusing {refusing}. Nothing at or above block {block_id} can be delivered from until that peer inscribes a block continuing the run verified from its genesis.",
+        hex::encode(peer_zone)
+    )
+}
+
+/// Whether `block` continues the peer chain pinned by `tip`.
+///
+/// `recomputed` is the hash [`screen_peer_block`] returned for it, so a tip
+/// stored off [`Link::Next`] pins contents rather than a declared field.
+///
+/// This is what closes the id suppression. A delivered message's replay key
+/// covers `(src_zone, src_block_id, src_tx_index)` and nothing else, so a peer
+/// that can get a block accepted under an id of its choosing burns the key an
+/// honest block would later use, and the inbox then no-ops the real message as
+/// a replay. Off a hash link ids are only claimable in order, so the only id
+/// within reach is the one the peer is about to publish anyway.
+#[must_use]
+pub fn link_to_tip(tip: Option<&PeerChainTip>, block: &Block, recomputed: HashType) -> Link {
+    let block_id = block.header.block_id;
+    let Some(tip) = tip else {
+        return if block_id == GENESIS_BLOCK_ID {
+            Link::Next(recomputed)
+        } else {
+            Link::OffChain(OffChain::NotTheGenesis { block_id })
+        };
+    };
+
+    if block_id <= tip.block_id {
+        return Link::AlreadySeen {
+            equivocates: block_id == tip.block_id && recomputed != tip.block_hash,
+        };
+    }
+    let next = tip.block_id.saturating_add(1);
+    if block_id > next {
+        return Link::OffChain(OffChain::SkipsAhead { block_id, next });
+    }
+    if block.header.prev_block_hash != tip.block_hash {
+        return Link::OffChain(OffChain::DoesNotLink {
+            block_id,
+            tip_id: tip.block_id,
+            links_to: block.header.prev_block_hash,
+            expected: tip.block_hash,
+        });
+    }
+    Link::Next(recomputed)
+}
+
+/// Whether a block read off a peer's channel may be considered for the chain at
+/// all, returning the recomputed hash every later placement has to use.
+pub fn screen_peer_block(
+    block: &Block,
+    expected_pubkey: Option<&PublicKey>,
+) -> Result<HashType, ScreenRefusal> {
+    let recomputed = block.recompute_hash();
+    if recomputed != block.header.hash {
+        return Err(ScreenRefusal::HashMismatch {
+            block_id: block.header.block_id,
+            declared: block.header.hash,
+            recomputed,
+        });
+    }
+    if expected_pubkey.is_some_and(|key| !block.is_signed_by(key)) {
+        return Err(ScreenRefusal::KeyMismatch {
+            block_id: block.header.block_id,
+        });
+    }
+    Ok(recomputed)
+}
+
+#[cfg(test)]
+mod tests {
+    use common::test_utils::produce_dummy_block;
+
+    use super::*;
+    use crate::test_utils::linked_chain_to;
+
+    /// The peer's block at `block_id`, on its one honest chain.
+    fn chain_block(block_id: u64) -> Block {
+        linked_chain_to(block_id, |_| vec![])
+            .pop()
+            .expect("chain reaches block_id")
+    }
+
+    /// The hash the block after `block_id` has to link to.
+    fn chain_hash(block_id: u64) -> HashType {
+        chain_block(block_id).header.hash
+    }
+
+    /// The tip a reader holds after accepting up to `block_id`.
+    fn tip_at(block_id: u64) -> PeerChainTip {
+        PeerChainTip {
+            block_id,
+            block_hash: chain_hash(block_id),
+        }
+    }
+
+    fn screened(block: &Block) -> HashType {
+        screen_peer_block(block, None).expect("honest block passes screening")
+    }
+
+    /// Runs the stall machine over `(stuck_on, read_to)` pass results.
+    fn run_stalls(passes: &[(Option<u64>, Option<u64>)]) -> StallState<u64> {
+        let mut state = StallState::default();
+        for (stuck_on, read_to) in passes {
+            state.after_pass(*stuck_on, *read_to);
+        }
+        state
+    }
+
+    #[test]
+    fn only_the_next_block_off_the_tip_links() {
+        let tip = tip_at(2);
+
+        let next = chain_block(3);
+        assert_eq!(
+            link_to_tip(Some(&tip), &next, screened(&next)),
+            Link::Next(chain_hash(3)),
+            "the block that continues the chain is the one accepted"
+        );
+
+        // The #677 suppression. The peer's chain is public, so the version that
+        // matters is the block linking correctly and lying only about the id:
+        // one with no link at all is caught by the same check and proves
+        // nothing about this one.
+        for ahead in [
+            produce_dummy_block(5, Some(chain_hash(2)), vec![]),
+            produce_dummy_block(5, None, vec![]),
+        ] {
+            assert_eq!(
+                link_to_tip(Some(&tip), &ahead, screened(&ahead)),
+                Link::OffChain(OffChain::SkipsAhead {
+                    block_id: 5,
+                    next: 3
+                })
+            );
+        }
+
+        // Right id, wrong ancestry: the peer forked at our tip, or reset it.
+        let forked = produce_dummy_block(3, Some(HashType([9; 32])), vec![]);
+        assert!(matches!(
+            link_to_tip(Some(&tip), &forked, screened(&forked)),
+            Link::OffChain(OffChain::DoesNotLink { .. })
+        ));
+    }
+
+    #[test]
+    fn a_reader_with_no_tip_starts_at_the_peers_genesis() {
+        let genesis = chain_block(GENESIS_BLOCK_ID);
+        assert_eq!(
+            link_to_tip(None, &genesis, screened(&genesis)),
+            Link::Next(chain_hash(GENESIS_BLOCK_ID))
+        );
+        // Anchoring on whatever arrived first is the whole attack: the peer
+        // would pick the id, and every key below it with one block.
+        let mid_chain = chain_block(GENESIS_BLOCK_ID + 1);
+        assert_eq!(
+            link_to_tip(None, &mid_chain, screened(&mid_chain)),
+            Link::OffChain(OffChain::NotTheGenesis {
+                block_id: GENESIS_BLOCK_ID + 1
+            })
+        );
+    }
+
+    #[test]
+    fn a_differing_block_at_the_tip_id_reports_equivocation() {
+        // Two blocks claiming one id collapse to one replay key on chain, so
+        // accepting both delivers one message twice. The re-read of the block
+        // the tip holds is ordinary; only a differing hash is worth a report.
+        let tip = tip_at(2);
+
+        let held = chain_block(2);
+        assert_eq!(
+            link_to_tip(Some(&tip), &held, screened(&held)),
+            Link::AlreadySeen { equivocates: false }
+        );
+
+        let differing = produce_dummy_block(2, Some(HashType([9; 32])), vec![]);
+        assert_eq!(
+            link_to_tip(Some(&tip), &differing, screened(&differing)),
+            Link::AlreadySeen { equivocates: true }
+        );
+
+        // Below the tip there is no held hash to compare against.
+        let below = produce_dummy_block(1, Some(HashType([9; 32])), vec![]);
+        assert_eq!(
+            link_to_tip(Some(&tip), &below, screened(&below)),
+            Link::AlreadySeen { equivocates: false }
+        );
+    }
+
+    #[test]
+    fn a_block_whose_header_hash_is_not_its_contents_is_refused() {
+        // A correctly signed block can still carry any value in `header.hash`.
+        let mut tampered = chain_block(3);
+        tampered.header.hash = HashType([9; 32]);
+        assert!(matches!(
+            screen_peer_block(&tampered, None),
+            Err(ScreenRefusal::HashMismatch { block_id: 3, .. })
+        ));
+
+        // And the hash verdict comes first, whatever else is wrong.
+        let other = lee::PublicKey::try_new([42; 32]).expect("test key");
+        assert!(matches!(
+            screen_peer_block(&tampered, Some(&other)),
+            Err(ScreenRefusal::HashMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn a_block_not_signed_by_the_pinned_key_is_refused() {
+        let signer = lee::PublicKey::new_from_private_key(
+            &lee::PrivateKey::try_new([37; 32]).expect("test key"),
+        );
+        let block = chain_block(GENESIS_BLOCK_ID);
+        assert_eq!(
+            screen_peer_block(&block, Some(&signer)),
+            Ok(chain_hash(GENESIS_BLOCK_ID)),
+            "produce_dummy_block signs with this key, so the pin must accept it"
+        );
+
+        let other = lee::PublicKey::try_new([42; 32]).expect("test key");
+        assert!(matches!(
+            screen_peer_block(&block, Some(&other)),
+            Err(ScreenRefusal::KeyMismatch {
+                block_id: GENESIS_BLOCK_ID
+            })
+        ));
+    }
+
+    #[test]
+    fn a_stuck_slot_is_counted_but_never_read_past() {
+        // Counting is only how loud to be about a slot a reader is stuck on;
+        // nothing here ever moves a cursor.
+        let passes = vec![(Some(4), Some(3)); 3];
+        assert_eq!(run_stalls(&passes).stalled, Some((4, 3)));
+
+        let long = vec![
+            (Some(4), Some(3));
+            usize::try_from(STUCK_SLOT_ALERT_PASSES).expect("alert threshold fits") * 2
+        ];
+        assert_eq!(
+            run_stalls(&long).stalled,
+            Some((4, STUCK_SLOT_ALERT_PASSES.saturating_mul(2))),
+            "a slot is retried for as long as it stays stuck"
+        );
+    }
+
+    #[test]
+    fn a_stream_that_ended_before_the_stalled_slot_does_not_reset_the_count() {
+        // The zone-sdk ends a stream on a fetch failure exactly as it does on
+        // catching up. Treating that as a clean pass would reset the count for
+        // ever, and a reader stuck for hours would never say so.
+        let mut passes = vec![(Some(4), Some(3)); 5];
+        passes.push((None, Some(3)));
+        assert_eq!(
+            run_stalls(&passes).stalled,
+            Some((4, 5)),
+            "the count survives a pass that never reached the stalled slot"
+        );
+
+        // Getting past it is what actually clears the stall.
+        let mut read_past = vec![(Some(4), Some(3)); 5];
+        read_past.push((None, Some(7)));
+        assert_eq!(run_stalls(&read_past).stalled, None);
+    }
+
+    #[test]
+    fn a_stall_at_a_new_slot_starts_its_own_count() {
+        let passes = [(Some(4), Some(3)), (Some(4), Some(3)), (Some(9), Some(8))];
+        assert_eq!(run_stalls(&passes).stalled, Some((9, 1)));
+    }
+
+    #[test]
+    fn a_stall_says_so_on_a_cadence_rather_than_once() {
+        // Reporting only on the crossing leaves a reader that never recovers
+        // looking resolved.
+        assert!(!alerts_at(0));
+        assert!(!alerts_at(1));
+        assert!(!alerts_at(STUCK_SLOT_ALERT_PASSES - 1));
+        assert!(alerts_at(STUCK_SLOT_ALERT_PASSES));
+        assert!(!alerts_at(STUCK_SLOT_ALERT_PASSES + 1));
+        assert!(alerts_at(STUCK_SLOT_ALERT_PASSES * 3));
+    }
+}

--- a/lez/cross_zone/src/lib.rs
+++ b/lez/cross_zone/src/lib.rs
@@ -9,6 +9,10 @@
 //! own block-reading, emission-extraction, delivery-building, and trust model; a
 //! shared trait is best lifted from that first real adapter, not from this one.
 
+pub use acceptance::{
+    Link, OffChain, STUCK_SLOT_ALERT_PASSES, ScreenRefusal, StallState, alerts_at,
+    equivocation_report, link_to_tip, screen_peer_block,
+};
 pub use cross_zone_inbox_core::{CrossZoneConfig, CrossZonePeer};
 use cross_zone_inbox_core::{
     CrossZoneMessage, InboxConfig, Instruction, ZoneId, inbox_config_account_id,
@@ -19,6 +23,10 @@ use lee_core::{
     program::ProgramId,
 };
 use serde::Serialize;
+
+pub mod acceptance;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod test_utils;
 
 /// The cross-zone emission fields a watcher or verifier reads off a source
 /// transaction, common to every emitter program.

--- a/lez/cross_zone/src/test_utils.rs
+++ b/lez/cross_zone/src/test_utils.rs
@@ -1,0 +1,51 @@
+//! Chain-builder helpers shared by the watcher's and verifier's tests, so both
+//! sides exercise the acceptance policy against identically built peer chains.
+
+use common::{block::Block, test_utils::produce_dummy_block, transaction::LeeTransaction};
+use cross_zone_inbox_core::ZoneId;
+use lee::{
+    GENESIS_BLOCK_ID, PublicTransaction,
+    public_transaction::{Message, WitnessSet},
+};
+use lee_core::program::ProgramId;
+use ping_core::{SenderInstruction, ping_record_pda, receiver_config_account_id};
+
+/// The peer's hash-linked chain from its genesis up to and including `last`,
+/// each block carrying the transactions `txs_at(block_id)` returns. Empty when
+/// `last` is below [`GENESIS_BLOCK_ID`].
+pub fn linked_chain_to(last: u64, txs_at: impl Fn(u64) -> Vec<LeeTransaction>) -> Vec<Block> {
+    let mut blocks: Vec<Block> = Vec::new();
+    for block_id in GENESIS_BLOCK_ID..=last {
+        let prev = blocks.last().map(|block| block.header.hash);
+        blocks.push(produce_dummy_block(block_id, prev, txs_at(block_id)));
+    }
+    blocks
+}
+
+/// A `ping_sender` emission aimed at `target_zone` and `target_program_id`,
+/// carrying `payload`. The sender lets its caller name any target, which is why
+/// routes pin the pair rather than the target alone.
+#[must_use]
+pub fn ping_emission(
+    target_zone: ZoneId,
+    target_program_id: ProgramId,
+    payload: &[u8],
+) -> LeeTransaction {
+    let receiver_id = programs::ping_receiver().id();
+    let send = SenderInstruction::Send {
+        target_zone,
+        target_program_id,
+        target_accounts: vec![
+            receiver_config_account_id(receiver_id).into_value(),
+            ping_record_pda(receiver_id).into_value(),
+        ],
+        payload: payload.to_vec(),
+        ordinal: 0,
+    };
+    let message = Message::try_new(programs::ping_sender().id(), vec![], vec![], send)
+        .expect("emission serializes");
+    LeeTransaction::Public(PublicTransaction::new(
+        message,
+        WitnessSet::from_raw_parts(vec![]),
+    ))
+}

--- a/lez/indexer/core/Cargo.toml
+++ b/lez/indexer/core/Cargo.toml
@@ -40,5 +40,6 @@ hex.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
+cross_zone = { workspace = true, features = ["test-utils"] }
 tempfile.workspace = true
 ping_core.workspace = true

--- a/lez/indexer/core/src/cross_zone_verifier.rs
+++ b/lez/indexer/core/src/cross_zone_verifier.rs
@@ -5,8 +5,14 @@ use std::{
 };
 
 use anyhow::anyhow;
-use common::{block::Block, transaction::LeeTransaction};
-use cross_zone::{EmissionSource, build_dispatch_from_emission, extract_emission};
+use common::{
+    block::{Block, PeerChainTip},
+    transaction::LeeTransaction,
+};
+use cross_zone::{
+    EmissionSource, Link, OffChain, StallState, alerts_at, build_dispatch_from_emission,
+    equivocation_report, extract_emission, link_to_tip, screen_peer_block,
+};
 use cross_zone_inbox_core::{
     CrossZoneMessage, Instruction as InboxInstruction, MessageKey, ZoneId, message_key,
 };
@@ -35,10 +41,6 @@ const PEER_BLOCK_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
 /// advanced by, so `waited` counts sleeps rather than wall time and, since a
 /// sleep can overshoot, understates it.
 const PEER_BLOCK_POLL_INTERVAL: Duration = Duration::from_secs(1);
-
-/// Consecutive passes a peer reader spends stuck on one slot before it says so
-/// as something more than the per-pass failure. It never reads past the slot.
-const STUCK_SLOT_ALERT_PASSES: u32 = 3;
 
 /// Why a cross-zone dispatch could not be verified.
 ///
@@ -73,44 +75,56 @@ type SeenKey = (MessageKey, [u8; 32]);
 #[derive(Default)]
 struct PeerChain {
     blocks: HashMap<u64, Block>,
-    /// Highest id such that every block from [`GENESIS_BLOCK_ID`] up to it has
-    /// been read and each links to its predecessor. `None` until genesis is read.
+    /// The head of the run: the highest id such that every block from
+    /// [`GENESIS_BLOCK_ID`] up to it has been read and each links to its
+    /// predecessor, plus that block's hash, pinned when [`Self::extend_prefix`]
+    /// walked it. `None` until genesis is read.
     ///
-    /// This, not `max(blocks.keys())`, is what the forgery test gates on: a peer
-    /// picks its own `block_id`s, and an id that does not continue the run
+    /// The id, not `max(blocks.keys())`, is what the forgery test gates on: a
+    /// peer picks its own `block_id`s, and an id that does not continue the run
     /// cannot advance the run.
+    ///
+    /// The hash is stored rather than re-read from `blocks`, so the tip
+    /// survives the tip block leaving the map; re-deriving it there would make
+    /// any future cache bounding misclassify the next honest block as
+    /// [`OffChain::NotTheGenesis`] and freeze the run.
     ///
     /// The link it walks means something only because [`accept_peer_block`]
     /// recomputes `header.hash` and checks the pinned key before anything is
     /// cached. Without that it compared two fields the peer wrote.
-    verified_prefix: Option<u64>,
+    verified_prefix: Option<PeerChainTip>,
 }
 
 impl PeerChain {
     /// The id that would extend the verified run.
     const fn next_expected(&self) -> u64 {
         match self.verified_prefix {
-            Some(prefix) => prefix.saturating_add(1),
+            Some(tip) => tip.block_id.saturating_add(1),
             None => GENESIS_BLOCK_ID,
         }
     }
 
-    /// Extends the verified run as far as the cached blocks allow.
+    /// Extends the verified run as far as the cached blocks allow, off the same
+    /// [`link_to_tip`] the watcher follows. The tip is pinned off [`Link::Next`],
+    /// whose hash [`accept_peer_block`] proved is the recomputed one.
     fn extend_prefix(&mut self) {
         while let Some(next) = self.blocks.get(&self.next_expected()) {
-            let links = match self.verified_prefix {
-                Some(prefix) => self
-                    .blocks
-                    .get(&prefix)
-                    .is_some_and(|prev| prev.header.hash == next.header.prev_block_hash),
-                // Genesis has no predecessor to link to.
-                None => true,
-            };
-            if !links {
-                return;
+            match link_to_tip(self.tip().as_ref(), next, next.header.hash) {
+                Link::Next(block_hash) => {
+                    self.verified_prefix = Some(PeerChainTip {
+                        block_id: next.header.block_id,
+                        block_hash,
+                    });
+                }
+                Link::AlreadySeen { .. } | Link::OffChain(_) => return,
             }
-            self.verified_prefix = Some(next.header.block_id);
         }
+    }
+
+    /// The tip pinning the verified run. `None` before the peer's genesis is
+    /// held.
+    const fn tip(&self) -> Option<PeerChainTip> {
+        self.verified_prefix
     }
 }
 
@@ -160,58 +174,84 @@ impl PeerBlocks {
     async fn insert(&self, zone: ZoneId, block: Block) -> bool {
         let mut chains = self.chains.write().await;
         let chain = chains.entry(zone).or_default();
-        let next = chain.next_expected();
 
-        // Below the peer's genesis as well as ahead of the run: an id under
-        // GENESIS_BLOCK_ID is on no chain the run can ever walk, and cached it
-        // would resolve as the peer's own block for ever after.
-        if block.header.block_id > next || block.header.block_id < GENESIS_BLOCK_ID {
-            debug!(
-                "Peer reader for {} not caching block {}: only block {next} continues the run verified from that peer's genesis.",
-                hex::encode(zone),
-                block.header.block_id
-            );
-            return false;
-        }
-
-        if let Some(held) = chain.blocks.get(&block.header.block_id) {
-            if held.header.hash == block.header.hash {
-                return false;
-            }
-            if block.header.block_id != next || !Self::extends_the_run(chain, &block) {
-                error!(
-                    "Peer zone {} equivocated at block {}: holding {}, refusing {}. Nothing at or above block {} can be delivered from until that peer inscribes a block continuing the run verified from its genesis.",
+        // `block` was screened on the way in, so `header.hash` is its
+        // recomputed hash and is what the synthesized tip pins.
+        let link = link_to_tip(chain.tip().as_ref(), &block, block.header.hash);
+        let continues_the_run = matches!(link, Link::Next(_));
+        match link {
+            // Ahead of the run, or a first read that is not the peer's genesis.
+            Link::OffChain(OffChain::NotTheGenesis { .. } | OffChain::SkipsAhead { .. }) => {
+                debug!(
+                    "Peer reader for {} not caching block {}: only block {} continues the run verified from that peer's genesis.",
                     hex::encode(zone),
                     block.header.block_id,
-                    held.header.hash,
-                    block.header.hash,
-                    block.header.block_id
+                    chain.next_expected()
                 );
-                return false;
+                false
             }
-            log::info!(
-                "Peer zone {} block {}: replacing held block {} with {}, which continues the verified run where the held one never could.",
-                hex::encode(zone),
-                block.header.block_id,
-                held.header.hash,
-                block.header.hash
-            );
+            Link::AlreadySeen { .. } => {
+                // Every id the run has walked is held; below the peer's genesis
+                // nothing is, and an id on no chain the run can ever walk must
+                // not be cached, or it would resolve as the peer's own block
+                // for ever after.
+                match chain.blocks.get(&block.header.block_id) {
+                    Some(held) if held.header.hash == block.header.hash => false,
+                    Some(held) => {
+                        error!(
+                            "{}",
+                            equivocation_report(
+                                &zone,
+                                block.header.block_id,
+                                held.header.hash,
+                                block.header.hash
+                            )
+                        );
+                        false
+                    }
+                    None => {
+                        debug!(
+                            "Peer reader for {} not caching block {}: below the peer's genesis, on no chain the run can walk.",
+                            hex::encode(zone),
+                            block.header.block_id
+                        );
+                        false
+                    }
+                }
+            }
+            // The one id that would extend the run. A block linking to the tip
+            // continues it; one that does not is cached only while the id is
+            // free, first write wins.
+            Link::Next(_) | Link::OffChain(OffChain::DoesNotLink { .. }) => {
+                if let Some(held) = chain.blocks.get(&block.header.block_id) {
+                    if held.header.hash == block.header.hash {
+                        return false;
+                    }
+                    if !continues_the_run {
+                        error!(
+                            "{}",
+                            equivocation_report(
+                                &zone,
+                                block.header.block_id,
+                                held.header.hash,
+                                block.header.hash
+                            )
+                        );
+                        return false;
+                    }
+                    log::info!(
+                        "Peer zone {} block {}: replacing held block {} with {}, which continues the verified run where the held one never could.",
+                        hex::encode(zone),
+                        block.header.block_id,
+                        held.header.hash,
+                        block.header.hash
+                    );
+                }
+                chain.blocks.insert(block.header.block_id, block);
+                chain.extend_prefix();
+                true
+            }
         }
-
-        chain.blocks.insert(block.header.block_id, block);
-        chain.extend_prefix();
-        true
-    }
-
-    /// Whether `block` links to the block at the head of the verified run.
-    ///
-    /// False before the peer's genesis has been read, so the first block at that
-    /// id wins and is never displaced, which is how the watcher anchors too.
-    fn extends_the_run(chain: &PeerChain, block: &Block) -> bool {
-        chain
-            .verified_prefix
-            .and_then(|prefix| chain.blocks.get(&prefix))
-            .is_some_and(|tip| block.header.prev_block_hash == tip.header.hash)
     }
 
     /// Resolves `block_id` under a single read lock.
@@ -235,7 +275,10 @@ impl PeerBlocks {
         let Some(chain) = chains.get(&zone) else {
             return PeerLookup::Behind;
         };
-        if chain.verified_prefix.is_none_or(|prefix| prefix < block_id) {
+        if chain
+            .verified_prefix
+            .is_none_or(|tip| tip.block_id < block_id)
+        {
             return PeerLookup::Behind;
         }
         chain
@@ -264,6 +307,7 @@ impl PeerBlocks {
             .await
             .get(&zone)
             .and_then(|chain| chain.verified_prefix)
+            .map(|tip| tip.block_id)
     }
 }
 
@@ -542,41 +586,26 @@ fn seen_key(msg: &CrossZoneMessage) -> SeenKey {
     )
 }
 
-/// Whether a block read off a peer's channel may enter the cache. The channel
-/// authorizes who may write, not what they may claim.
+/// Whether a block read off a peer's channel may enter the cache, screened by
+/// the same [`screen_peer_block`] policy the watcher applies. [`ScreenRefusal`]
+/// says why each check exists.
 ///
-/// The hash check is unconditional: `header.hash` is a field the peer wrote and
-/// the prefix walk compares it against the next block's `prev_block_hash`, so
-/// without recomputing it a peer can assert links it never built. The key check
-/// applies only when one is pinned, mirroring the watcher; it subsumes the hash
-/// check, but a peer with no pinned key still gets that one.
+/// [`ScreenRefusal`]: cross_zone::ScreenRefusal
 fn accept_peer_block(
     block: &Block,
     peer_zone: ZoneId,
     expected_pubkey: Option<&PublicKey>,
 ) -> bool {
-    if block.recompute_hash() != block.header.hash {
-        warn!(
-            "Peer reader dropping block {} from {}: header hash {} does not match its contents",
-            block.header.block_id,
-            hex::encode(peer_zone),
-            block.header.hash
-        );
-        return false;
+    match screen_peer_block(block, expected_pubkey) {
+        Ok(_) => true,
+        Err(refusal) => {
+            warn!(
+                "Peer reader dropping block from {}: {refusal}",
+                hex::encode(peer_zone)
+            );
+            false
+        }
     }
-
-    if let Some(expected) = expected_pubkey
-        && !block.is_signed_by(expected)
-    {
-        warn!(
-            "Peer reader dropping block {} from {}: not signed by the pinned block-signing key",
-            block.header.block_id,
-            hex::encode(peer_zone)
-        );
-        return false;
-    }
-
-    true
 }
 
 /// Reads a peer zone's finalized blocks from Bedrock into the shared cache.
@@ -597,10 +626,9 @@ async fn read_peer(
     );
 
     let mut cursor = None;
-    // The slot the reader is stuck on and how many passes it has spent there.
-    // Keyed by slot so a failure at a new slot does not inherit an older slot's
-    // count, and used only to say so once rather than every pass.
-    let mut stalled: Option<(Slot, u32)> = None;
+    // In memory only: it says how loud to be about a slot this reader is stuck
+    // on.
+    let mut stall = StallState::default();
     loop {
         match zone_indexer.next_messages(cursor).await {
             Ok(stream) => {
@@ -613,23 +641,13 @@ async fn read_peer(
                 )
                 .await;
                 cursor = pass.cursor;
-                if let Some(slot) = pass.stalled_at {
-                    let attempts = match stalled {
-                        Some((prev, attempts)) if prev == slot => attempts.saturating_add(1),
-                        _ => 1,
-                    };
-                    stalled = Some((slot, attempts));
-                    // Every threshold rather than on the crossing alone: a stall
-                    // that never clears would otherwise be reported once and
-                    // then look resolved for as long as it lasts.
-                    if attempts > 0 && attempts.is_multiple_of(STUCK_SLOT_ALERT_PASSES) {
-                        error!(
-                            "Peer reader for {} has been stuck at slot {slot:?} for {attempts} passes. The run verified from that peer's genesis stops below it, so every dispatch naming a later block stalls until this slot can be read.",
-                            hex::encode(peer_zone)
-                        );
-                    }
-                } else {
-                    stalled = None;
+                if let Some((slot, attempts)) = stall.after_pass(pass.stalled_at, pass.cursor)
+                    && alerts_at(attempts)
+                {
+                    error!(
+                        "Peer reader for {} has been stuck at slot {slot:?} for {attempts} passes. The run verified from that peer's genesis stops below it, so every dispatch naming a later block stalls until this slot can be read.",
+                        hex::encode(peer_zone)
+                    );
                 }
             }
             Err(err) => error!(
@@ -711,14 +729,12 @@ where
 #[cfg(test)]
 mod tests {
     use common::{HashType, test_utils::produce_dummy_block};
+    use cross_zone::test_utils::{linked_chain_to, ping_emission};
     use futures::stream;
-    use lee::{
-        PrivateKey, PublicKey, PublicTransaction,
-        public_transaction::{Message, WitnessSet},
-    };
+    use lee::{PrivateKey, PublicKey};
     use logos_blockchain_core::mantle::ops::channel::{MsgId, inscribe::Inscription};
     use logos_blockchain_zone_sdk::ZoneBlock;
-    use ping_core::{SenderInstruction, ping_record_pda, receiver_config_account_id};
+    use ping_core::{ping_record_pda, receiver_config_account_id};
 
     use super::*;
 
@@ -744,23 +760,7 @@ mod tests {
 
     /// A `ping_sender` emission addressed to `SELF_ZONE` carrying `payload`.
     fn emission(payload: &[u8]) -> LeeTransaction {
-        let receiver_id = programs::ping_receiver().id();
-        let send = SenderInstruction::Send {
-            target_zone: SELF_ZONE,
-            target_program_id: receiver_id,
-            target_accounts: vec![
-                receiver_config_account_id(receiver_id).into_value(),
-                ping_record_pda(receiver_id).into_value(),
-            ],
-            payload: payload.to_vec(),
-            ordinal: 0,
-        };
-        let message = Message::try_new(programs::ping_sender().id(), vec![], vec![], send)
-            .expect("emission serializes");
-        LeeTransaction::Public(PublicTransaction::new(
-            message,
-            WitnessSet::from_raw_parts(vec![]),
-        ))
+        ping_emission(SELF_ZONE, programs::ping_receiver().id(), payload)
     }
 
     /// A peer-stream item inscribing `data` at `slot`.
@@ -777,18 +777,10 @@ mod tests {
     /// A hash-linked chain of `len` blocks from genesis, each carrying a `b"hi"`
     /// emission. Only a chain built this way advances the verified prefix.
     fn linked_chain(len: u64) -> Vec<Block> {
-        let mut prev = None;
-        let mut blocks = Vec::new();
-        for offset in 0..len {
-            let block = produce_dummy_block(
-                GENESIS_BLOCK_ID.saturating_add(offset),
-                prev,
-                vec![emission(b"hi")],
-            );
-            prev = Some(block.header.hash);
-            blocks.push(block);
-        }
-        blocks
+        linked_chain_to(
+            GENESIS_BLOCK_ID.saturating_add(len).saturating_sub(1),
+            |_| vec![emission(b"hi")],
+        )
     }
 
     /// A peer-stream item carrying `block`.
@@ -800,14 +792,13 @@ mod tests {
     /// `PEER_BLOCK_ID`, carries a `payload` emission. The run is what makes that
     /// block deliverable.
     fn peer_chain(payload: &[u8]) -> Vec<Block> {
-        let mut chain = linked_chain(PEER_BLOCK_ID.saturating_sub(GENESIS_BLOCK_ID));
-        let prev = chain.last().map(|block| block.header.hash);
-        chain.push(produce_dummy_block(
-            PEER_BLOCK_ID,
-            prev,
-            vec![emission(payload)],
-        ));
-        chain
+        linked_chain_to(PEER_BLOCK_ID, |block_id| {
+            vec![if block_id == PEER_BLOCK_ID {
+                emission(payload)
+            } else {
+                emission(b"hi")
+            }]
+        })
     }
 
     /// Caches a run so its last block sits inside the verified prefix.
@@ -1071,6 +1062,42 @@ mod tests {
         ));
         assert!(matches!(
             peers.resolve(PEER_ZONE, 3).await,
+            PeerLookup::Behind
+        ));
+    }
+
+    #[tokio::test]
+    async fn the_tip_survives_the_tip_block_leaving_the_cache() {
+        // The tip is pinned at walk time, not re-derived from the blocks map:
+        // re-derived, evicting the tip block (any future cache bounding) would
+        // read as no tip at all, and the next honest block would misclassify as
+        // NotTheGenesis and freeze the run for good.
+        let peers = PeerBlocks::default();
+        let chain = linked_chain(3);
+        for block in chain.iter().take(2).cloned() {
+            peers.insert(PEER_ZONE, block).await;
+        }
+        peers
+            .chains
+            .write()
+            .await
+            .get_mut(&PEER_ZONE)
+            .expect("chain exists")
+            .blocks
+            .remove(&2);
+
+        assert!(
+            peers.insert(PEER_ZONE, chain[2].clone()).await,
+            "the next block still extends the run off the pinned tip"
+        );
+        assert_eq!(peers.verified_prefix(PEER_ZONE).await, Some(3));
+        // The evicted id keeps its classification: inside the run and absent.
+        assert!(matches!(
+            peers.resolve(PEER_ZONE, 2).await,
+            PeerLookup::InsideRun
+        ));
+        assert!(matches!(
+            peers.resolve(PEER_ZONE, 4).await,
             PeerLookup::Behind
         ));
     }

--- a/lez/sequencer/core/Cargo.toml
+++ b/lez/sequencer/core/Cargo.toml
@@ -54,6 +54,7 @@ testnet = []
 mock = []
 
 [dev-dependencies]
+cross_zone = { workspace = true, features = ["test-utils"] }
 futures.workspace = true
 test_programs.workspace = true
 lee = { workspace = true, features = ["test-utils"] }

--- a/lez/sequencer/core/src/cross_zone_watcher.rs
+++ b/lez/sequencer/core/src/cross_zone_watcher.rs
@@ -2,11 +2,12 @@ use std::{sync::Arc, time::Duration};
 
 use common::{HashType, block::Block, transaction::LeeTransaction};
 use cross_zone::{
-    EmissionSource, build_dispatch_from_emission, extract_emission, is_sequencer_only_program,
+    EmissionSource, Link, StallState, alerts_at, build_dispatch_from_emission, equivocation_report,
+    extract_emission, is_sequencer_only_program, link_to_tip, screen_peer_block,
 };
 use cross_zone_inbox_core::message_key;
 use futures::{Stream, StreamExt as _};
-use lee::{GENESIS_BLOCK_ID, PublicKey};
+use lee::PublicKey;
 use log::{debug, error, warn};
 use logos_blockchain_core::mantle::ops::channel::ChannelId;
 use logos_blockchain_zone_sdk::{
@@ -25,15 +26,6 @@ use crate::{
     task_group::TaskGroup,
 };
 
-/// Consecutive passes a watcher spends stuck on one slot before it says so as
-/// something more than the per-pass failure.
-///
-/// One pass per poll interval, which is the block time, so this is minutes of
-/// retrying rather than seconds. A transient failure (a truncated read, a peer
-/// mid-upgrade) heals well inside that; anything still stuck after it wants
-/// someone to look.
-const STUCK_SLOT_ALERT_PASSES: u32 = 20;
-
 /// The per-peer settings one watcher pass needs.
 struct PeerContext {
     peer_zone: [u8; 32],
@@ -46,7 +38,7 @@ struct PeerContext {
 /// All of them hold the delivery floor at the last slot the watcher consumed
 /// whole, bar [`PassOutcome::Drained`] and [`PassOutcome::Stranded`], so the
 /// next pass re-reads from there. Only a block that will not deserialize ends a
-/// pass; [`link_against`] says why one that decodes never does.
+/// pass; [`link_to_tip`] says why one that decodes never does.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum PassOutcome {
     /// The stream drained, having delivered from at least one block or found
@@ -71,10 +63,7 @@ enum PassOutcome {
 /// The pass-to-pass state of one watcher.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 struct WatcherState {
-    /// The slot it is stuck on and how many consecutive passes it has spent
-    /// there. Keyed by slot so a failure at a new slot does not inherit an
-    /// older slot's count.
-    stalled: Option<(Slot, u32)>,
+    stall: StallState<Slot>,
     /// Consecutive passes that placed nothing while skipping blocks. Not keyed
     /// by slot: the peer keeps producing, so every such pass ends at a new slot
     /// and a slot-keyed count would reset to one for ever.
@@ -82,44 +71,19 @@ struct WatcherState {
 }
 
 impl WatcherState {
-    /// Folds one pass's outcome in, returning the slot the watcher is stuck on
-    /// and how long it has been stuck, so the caller can say so.
-    ///
-    /// `cursor` is the read position after the pass, and is what tells a stream
-    /// that truncated early apart from one that genuinely drained: the zone-sdk
-    /// ends a stream on a fetch failure exactly as it does on catching up, so
-    /// without it a flaky peer endpoint resets the count for ever and a watcher
-    /// stuck for hours never says so.
+    /// Folds one pass's outcome into the stall and stranded counts, returning
+    /// the slot the watcher is stuck on and how long it has been stuck.
     fn after_pass(&mut self, outcome: PassOutcome, cursor: Option<Slot>) -> Option<(Slot, u32)> {
-        let slot = match outcome {
-            PassOutcome::Drained | PassOutcome::Stranded => {
-                if self.passed_the_stall(cursor) {
-                    self.stalled = None;
-                }
-                self.stranded = match outcome {
-                    PassOutcome::Stranded => self.stranded.saturating_add(1),
-                    PassOutcome::Drained
-                    | PassOutcome::Undecodable(_)
-                    | PassOutcome::Undelivered(_) => 0,
-                };
-                return None;
-            }
-            PassOutcome::Undecodable(slot) | PassOutcome::Undelivered(slot) => slot,
+        match outcome {
+            PassOutcome::Stranded => self.stranded = self.stranded.saturating_add(1),
+            PassOutcome::Drained => self.stranded = 0,
+            PassOutcome::Undecodable(_) | PassOutcome::Undelivered(_) => {}
+        }
+        let stuck_on = match outcome {
+            PassOutcome::Undecodable(slot) | PassOutcome::Undelivered(slot) => Some(slot),
+            PassOutcome::Drained | PassOutcome::Stranded => None,
         };
-
-        let attempts = match self.stalled {
-            Some((stuck_on, attempts)) if stuck_on == slot => attempts.saturating_add(1),
-            _ => 1,
-        };
-        self.stalled = Some((slot, attempts));
-        self.stalled
-    }
-
-    /// Whether the read position is now past whatever the watcher was stuck on.
-    /// Vacuously true when it was not stuck.
-    fn passed_the_stall(self, cursor: Option<Slot>) -> bool {
-        self.stalled
-            .is_none_or(|(stuck_on, _)| cursor.is_some_and(|read_to| read_to >= stuck_on))
+        self.stall.after_pass(stuck_on, cursor)
     }
 }
 
@@ -130,96 +94,6 @@ struct Resume {
     cursor: Option<Slot>,
     /// Whether the stored floor has to be dropped before anything is read.
     clear_floor: bool,
-}
-
-/// Where a peer block sits relative to the chain this watcher has delivered
-/// from.
-#[derive(Debug, PartialEq, Eq)]
-enum Link {
-    /// The next block on the peer's chain, carrying its recomputed hash.
-    Next(HashType),
-    /// At or below the tip, so already delivered from. The ordinary shape of a
-    /// re-read slot, and how an equivocating second block at one id is refused.
-    AlreadySeen,
-    /// Not on the chain this watcher is following, so not deliverable. Read on:
-    /// the peer's own next block still links to the tip, and treating this as
-    /// terminal would hand the peer a way to stop its deliveries permanently.
-    OffChain(String),
-}
-
-/// Whether `block` continues the peer chain pinned by `tip`.
-///
-/// This is what closes the suppression. A delivered message's replay key covers
-/// `(src_zone, src_block_id, src_tx_index)` and nothing else, so a peer that can
-/// get a block delivered under an id of its choosing burns the key an honest
-/// block would later use, and the inbox then no-ops the real message as a
-/// replay. Off a hash link ids are only claimable in order, so the only id
-/// within reach is the one the peer is about to publish anyway.
-///
-/// Nothing but [`Link::Next`] is ever delivered from, and nothing but a block
-/// that will not decode stops the pass. A peer can inscribe anything it likes on
-/// its own channel, so a block this watcher cannot place is read past rather
-/// than treated as the end of the chain: the peer's own next honest block still
-/// links to the tip.
-fn link_against(
-    tip: Option<PeerChainTip>,
-    block: &Block,
-    expected_pubkey: Option<&PublicKey>,
-) -> Link {
-    // The channel authorizes who may write, not what they may claim, so the
-    // pinned key is what says this node's own sequencer produced the block.
-    if expected_pubkey.is_some_and(|key| !block.is_signed_by(key)) {
-        return Link::OffChain("block-signing key does not match the pinned key".to_owned());
-    }
-
-    let recomputed = block.recompute_hash();
-    if recomputed != block.header.hash {
-        // The signature does not cover this field, so a correctly signed block
-        // may still carry a bogus one, and the peer's own next block links
-        // against the recomputed value rather than this one.
-        return Link::OffChain(format!(
-            "block {} carries header hash {} but its contents hash to {recomputed}",
-            block.header.block_id, block.header.hash
-        ));
-    }
-
-    let Some(tip) = tip else {
-        return if block.header.block_id == GENESIS_BLOCK_ID {
-            Link::Next(recomputed)
-        } else {
-            Link::OffChain(format!(
-                "block {} is the first one read, but a watcher with no stored chain tip has to start at the peer's genesis block {GENESIS_BLOCK_ID}",
-                block.header.block_id
-            ))
-        };
-    };
-
-    if block.header.block_id <= tip.block_id {
-        return Link::AlreadySeen;
-    }
-    if block.header.block_id > tip.block_id.saturating_add(1) {
-        return Link::OffChain(format!(
-            "block {} skips past {}, which is either a hole in what this node read or an id claimed ahead of the peer's chain",
-            block.header.block_id,
-            tip.block_id.saturating_add(1)
-        ));
-    }
-    if block.header.prev_block_hash != tip.block_hash {
-        return Link::OffChain(format!(
-            "block {} does not follow block {} we delivered from: it links to {} rather than {}",
-            block.header.block_id, tip.block_id, block.header.prev_block_hash, tip.block_hash
-        ));
-    }
-    Link::Next(recomputed)
-}
-
-/// Whether a watcher stuck for `attempts` passes should say so on this one.
-///
-/// Every [`STUCK_SLOT_ALERT_PASSES`], not on the crossing alone: a stall that
-/// never clears would otherwise be reported once and then look resolved for as
-/// long as it lasts. Not every pass, since that is one line per block time.
-const fn alerts_at(attempts: u32) -> bool {
-    attempts > 0 && attempts.is_multiple_of(STUCK_SLOT_ALERT_PASSES)
 }
 
 /// Where a starting watcher resumes reading a peer's channel.
@@ -452,13 +326,42 @@ where
                     hex::encode(peer.peer_zone),
                     block.header.block_id
                 );
-                match link_against(*tip, &block, peer.expected_pubkey.as_ref()) {
-                    Link::AlreadySeen => {
-                        debug!(
-                            "Watcher ignoring peer {} block {}: at or below the block it has already delivered from",
-                            hex::encode(peer.peer_zone),
-                            block.header.block_id
+                // Nothing but [`Link::Next`] is ever delivered from, and
+                // nothing but a block that will not decode stops the pass. A
+                // peer can inscribe anything it likes on its own channel, so a
+                // block this watcher cannot place is read past rather than
+                // treated as the end of the chain: the peer's own next honest
+                // block still links to the tip.
+                let link = match screen_peer_block(&block, peer.expected_pubkey.as_ref()) {
+                    Ok(recomputed) => link_to_tip(tip.as_ref(), &block, recomputed),
+                    Err(refusal) => {
+                        skipped = skipped.saturating_add(1);
+                        warn!(
+                            "Watcher not delivering from peer {} block at slot {slot:?}: {refusal}. Reading on; the peer's next block that continues the chain still delivers.",
+                            hex::encode(peer.peer_zone)
                         );
+                        continue;
+                    }
+                };
+                match link {
+                    Link::AlreadySeen { equivocates } => {
+                        if equivocates && let Some(held) = *tip {
+                            error!(
+                                "{}",
+                                equivocation_report(
+                                    &peer.peer_zone,
+                                    block.header.block_id,
+                                    held.block_hash,
+                                    block.header.hash
+                                )
+                            );
+                        } else {
+                            debug!(
+                                "Watcher ignoring peer {} block {}: at or below the block it has already delivered from",
+                                hex::encode(peer.peer_zone),
+                                block.header.block_id
+                            );
+                        }
                     }
                     Link::OffChain(reason) => {
                         skipped = skipped.saturating_add(1);
@@ -546,8 +449,8 @@ fn advance_cursor(dbio: &RocksDBIO, peer_zone: [u8; 32], cursor: &mut Option<Slo
 /// into a stall: the record is the only thing standing between a durable read
 /// position and a lost message.
 ///
-/// `block_hash` is the value [`link_against`] recomputed from the block's own
-/// contents, not `block.header.hash`, which the signature does not cover.
+/// `block_hash` is the value [`screen_peer_block`] recomputed from the block's
+/// own contents, not `block.header.hash`, which the signature does not cover.
 fn record_block_deliveries(
     block: &Block,
     block_hash: HashType,
@@ -658,14 +561,10 @@ fn record_block_deliveries(
 #[cfg(test)]
 mod tests {
     use common::test_utils::produce_dummy_block;
+    use cross_zone::test_utils::{linked_chain_to, ping_emission};
     use futures::stream;
-    use lee::{
-        PublicTransaction,
-        public_transaction::{Message, WitnessSet},
-    };
     use logos_blockchain_core::mantle::ops::channel::{MsgId, inscribe::Inscription};
     use logos_blockchain_zone_sdk::ZoneBlock;
-    use ping_core::{SenderInstruction, ping_record_pda, receiver_config_account_id};
     use storage::sequencer::{DB_META_PENDING_CROSS_ZONE_DISPATCHES_KEY, RocksDBIO};
     use tempfile::TempDir;
 
@@ -695,27 +594,9 @@ mod tests {
         emission_to(programs::ping_receiver().id())
     }
 
-    /// A `ping_sender` emission aimed at `target_program_id`. The sender lets its
-    /// caller name any target, which is exactly why the route has to pin the
-    /// pair rather than the target alone.
+    /// A `ping_sender` emission aimed at `target_program_id`.
     fn emission_to(target_program_id: lee_core::program::ProgramId) -> LeeTransaction {
-        let receiver_id = programs::ping_receiver().id();
-        let send = SenderInstruction::Send {
-            target_zone: SELF_ZONE,
-            target_program_id,
-            target_accounts: vec![
-                receiver_config_account_id(receiver_id).into_value(),
-                ping_record_pda(receiver_id).into_value(),
-            ],
-            payload: b"hi".to_vec(),
-            ordinal: 0,
-        };
-        let message = Message::try_new(programs::ping_sender().id(), vec![], vec![], send)
-            .expect("emission serializes");
-        LeeTransaction::Public(PublicTransaction::new(
-            message,
-            WitnessSet::from_raw_parts(vec![]),
-        ))
+        ping_emission(SELF_ZONE, target_program_id, b"hi")
     }
 
     fn peer_msg(data: Vec<u8>, slot: u64) -> (ZoneMessage, Slot) {
@@ -730,14 +611,9 @@ mod tests {
 
     /// The peer's chain from its genesis up to and including `block_id`, each
     /// block linked to the one before it and carrying one emission for this
-    /// zone. Empty below [`GENESIS_BLOCK_ID`].
+    /// zone.
     fn chain_to(block_id: u64) -> Vec<Block> {
-        let mut blocks: Vec<Block> = Vec::new();
-        for id in GENESIS_BLOCK_ID..=block_id {
-            let prev = blocks.last().map(|block| block.header.hash);
-            blocks.push(produce_dummy_block(id, prev, vec![emission()]));
-        }
-        blocks
+        linked_chain_to(block_id, |_| vec![emission()])
     }
 
     /// The peer's block at `block_id`.
@@ -826,60 +702,6 @@ mod tests {
         state
     }
 
-    fn stall(slot: u64, cursor: Option<u64>) -> (PassOutcome, Option<u64>) {
-        (PassOutcome::Undecodable(Slot::from(slot)), cursor)
-    }
-
-    #[test]
-    fn a_stuck_slot_is_counted_but_never_read_past() {
-        // The watcher used to give up on a slot and read past it. Counting is
-        // now only how loud to be about one it is stuck on.
-        let passes = vec![stall(4, Some(3)); 3];
-        assert_eq!(run_passes(&passes).stalled, Some((Slot::from(4), 3)));
-
-        let long = vec![
-            stall(4, Some(3));
-            usize::try_from(STUCK_SLOT_ALERT_PASSES).expect("alert threshold fits") * 2
-        ];
-        assert_eq!(
-            run_passes(&long).stalled,
-            Some((Slot::from(4), STUCK_SLOT_ALERT_PASSES.saturating_mul(2))),
-            "a slot is retried for as long as it stays stuck"
-        );
-    }
-
-    #[test]
-    fn a_stream_that_ended_before_the_stalled_slot_does_not_reset_the_count() {
-        // The zone-sdk ends a stream on a fetch failure exactly as it does on
-        // catching up. Treating that as a clean pass would reset the count for
-        // ever, and a watcher stuck for hours would never say so.
-        let mut passes = vec![stall(4, Some(3)); 5];
-        passes.push((PassOutcome::Drained, Some(3)));
-        let state = run_passes(&passes);
-        assert_eq!(
-            state.stalled,
-            Some((Slot::from(4), 5)),
-            "the count survives a pass that never reached the stalled slot"
-        );
-
-        // Getting past it is what actually clears the stall.
-        let mut read_past = vec![stall(4, Some(3)); 5];
-        read_past.push((PassOutcome::Drained, Some(7)));
-        assert_eq!(run_passes(&read_past).stalled, None);
-    }
-
-    #[test]
-    fn a_stall_says_so_on_a_cadence_rather_than_once() {
-        // Reporting only on the crossing leaves a watcher that never recovers
-        // looking resolved, which is the failure this whole commit is about.
-        assert!(!alerts_at(0));
-        assert!(!alerts_at(1));
-        assert!(!alerts_at(STUCK_SLOT_ALERT_PASSES - 1));
-        assert!(alerts_at(STUCK_SLOT_ALERT_PASSES));
-        assert!(!alerts_at(STUCK_SLOT_ALERT_PASSES + 1));
-        assert!(alerts_at(STUCK_SLOT_ALERT_PASSES * 3));
-    }
-
     #[test]
     fn passes_that_place_nothing_while_skipping_blocks_are_counted() {
         // A tip that stops tracking the peer is silent by construction: every
@@ -904,12 +726,6 @@ mod tests {
     }
 
     #[test]
-    fn a_stall_at_a_new_slot_starts_its_own_count() {
-        let passes = vec![stall(4, Some(3)), stall(4, Some(3)), stall(9, Some(8))];
-        assert_eq!(run_passes(&passes).stalled, Some((Slot::from(9), 1)));
-    }
-
-    #[test]
     fn every_way_of_ending_early_keeps_the_slot_coming_back() {
         // Undecodable and undelivered differ in whose problem they are, not in
         // what the watcher does about them: hold the floor and read the slot
@@ -918,104 +734,12 @@ mod tests {
             PassOutcome::Undecodable(Slot::from(4)),
             PassOutcome::Undelivered(Slot::from(4)),
         ] {
+            let mut state = WatcherState::default();
             assert_eq!(
-                run_passes(&[(outcome, Some(3))]).stalled,
+                state.after_pass(outcome, Some(Slot::from(3))),
                 Some((Slot::from(4), 1))
             );
         }
-    }
-
-    #[test]
-    fn only_the_next_block_off_the_tip_links() {
-        let tip = Some(tip_at(2));
-
-        assert_eq!(
-            link_against(tip, &chain_block(3), None),
-            Link::Next(chain_hash(3)),
-            "the block that continues the chain is the one delivered from"
-        );
-
-        // The #677 suppression. The peer's chain is public, so the version that
-        // matters is the block linking correctly and lying only about the id:
-        // one with no link at all is caught by the check below and proves
-        // nothing about this one.
-        assert!(matches!(
-            link_against(
-                tip,
-                &produce_dummy_block(5, Some(chain_hash(2)), vec![emission()]),
-                None
-            ),
-            Link::OffChain(_)
-        ));
-        assert!(matches!(
-            link_against(tip, &produce_dummy_block(5, None, vec![emission()]), None),
-            Link::OffChain(_)
-        ));
-
-        // Two blocks claiming one id collapse to one key on chain, so
-        // delivering from both delivers one message twice.
-        assert_eq!(link_against(tip, &chain_block(2), None), Link::AlreadySeen);
-        assert_eq!(
-            link_against(
-                tip,
-                &produce_dummy_block(2, Some(HashType([9; 32])), vec![emission()]),
-                None
-            ),
-            Link::AlreadySeen
-        );
-
-        // Right id, wrong ancestry: the peer forked at our tip, or reset it.
-        assert!(matches!(
-            link_against(
-                tip,
-                &produce_dummy_block(3, Some(HashType([9; 32])), vec![emission()]),
-                None
-            ),
-            Link::OffChain(_)
-        ));
-    }
-
-    #[test]
-    fn a_watcher_with_no_tip_starts_at_the_peers_genesis() {
-        assert_eq!(
-            link_against(None, &chain_block(GENESIS_BLOCK_ID), None),
-            Link::Next(chain_hash(GENESIS_BLOCK_ID))
-        );
-        // Anchoring on whatever arrived first is the whole attack: the peer
-        // would pick the id, and every key below it with one block.
-        assert!(matches!(
-            link_against(None, &chain_block(GENESIS_BLOCK_ID + 1), None),
-            Link::OffChain(_)
-        ));
-    }
-
-    #[test]
-    fn a_block_whose_header_hash_is_not_its_contents_is_off_chain() {
-        // A correctly signed block can still carry any value in `header.hash`.
-        let mut tampered = chain_block(3);
-        tampered.header.hash = HashType([9; 32]);
-        assert!(matches!(
-            link_against(Some(tip_at(2)), &tampered, None),
-            Link::OffChain(_)
-        ));
-    }
-
-    #[test]
-    fn a_block_not_signed_by_the_pinned_key_is_not_delivered_from() {
-        let signer = lee::PublicKey::new_from_private_key(
-            &lee::PrivateKey::try_new([37; 32]).expect("test key"),
-        );
-        assert_eq!(
-            link_against(None, &chain_block(GENESIS_BLOCK_ID), Some(&signer)),
-            Link::Next(chain_hash(GENESIS_BLOCK_ID)),
-            "produce_dummy_block signs with this key, so the pin must accept it"
-        );
-
-        let other = lee::PublicKey::try_new([42; 32]).expect("test key");
-        assert!(matches!(
-            link_against(None, &chain_block(GENESIS_BLOCK_ID), Some(&other)),
-            Link::OffChain(_)
-        ));
     }
 
     #[test]

--- a/lez/storage/src/sequencer/sequencer_cells.rs
+++ b/lez/storage/src/sequencer/sequencer_cells.rs
@@ -1,4 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
+pub use common::block::PeerChainTip;
 use common::{HashType, block::BlockMeta};
 use lee::V03State;
 
@@ -542,21 +543,8 @@ impl SimpleWritableCell for PeerFloorCellRef<'_> {
     }
 }
 
-/// The last peer block a cross-zone watcher delivered from, and the link the
-/// next one has to carry.
-///
-/// `block_hash` is the recomputed hash, not `header.hash` as read: the
-/// signature does not cover that field, so a signed block may carry a bogus one
-/// and break the link against the peer's next honest block.
-///
-/// Durable, not in-memory: a watcher that re-anchored on restart would accept a
-/// block claiming any id.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
-pub struct PeerChainTip {
-    pub block_id: u64,
-    pub block_hash: HashType,
-}
-
+/// The watcher's [`PeerChainTip`], durable rather than in-memory: a watcher
+/// that re-anchored on restart would accept a block claiming any id.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct PeerTipCell(pub PeerChainTip);
 


### PR DESCRIPTION
## 🎯 Purpose

Closes #674.

The sequencer's watcher and the indexer's verifier must derive identical dispatch sets from the same peer stream, or the indexer calls the sequencer's delivery forged and halts. They judged peer blocks with duplicated code: the same checks in opposite order, different alert cadences, and drift room wherever one side changed and the other did not. Both sides now accumulate per-peer chain state, where any divergence forks derivation permanently.

## ⚙️ Approach

- [x] One `cross_zone::acceptance` module: block screening (hash recomputation, then pinned key), chain linking (genesis anchor, next id, predecessor hash), and the stall counter with one alert cadence, replacing 20 versus 3 with 5
- [x] The watcher adopts it, and gains the verifier's explicit equivocation report for a differing hash at its tip id
- [x] The verifier adopts it: cache admission, run extension and screening route through the same predicates; its run tip now carries its own hash, so a future cache bound cannot freeze the run
- [x] `PeerChainTip` moves to `common` (storage re-exports it, schema unchanged), keeping the policy crate free of rocksdb
- [x] The pure predicate tests and the duplicated chain-builder test helpers are shared

Stated behavior changes, all log or robustness side: unified check order and refusal texts; both alert cadences at 5, including the watcher's stranded alert; the watcher reports equivocation at its tip id where it previously stayed silent (below the tip it has no held hashes, so the verifier remains the louder of the two); the verifier's stall counter no longer resets when a stream truncates before the stalled slot.

Out of scope, deliberately: the two stream loops stay separate (the watcher persists floors and records deliveries mid-loop, the verifier is a pure cache), gap handling keeps its per-side semantics (the watcher skips to keep delivering, the verifier waits for canonicality; both act only on hash-linked runs), and the sequencer-only target filter stays watcher-side only, as its comment already requires.

## 🧪 How to Test

`cargo test -p cross_zone -p indexer_core`, `RISC0_DEV_MODE=1 cargo test --release -p sequencer_core --features mock`, and the `cross_zone_verified`, `cross_zone_watcher_restart` and `cross_zone_ping` e2e.

## 🔗 Dependencies

#697

## 📋 PR Completion Checklist

*Mark only completed items. A complete PR should have all boxes ticked.*

- [x] Complete PR description
- [x] Implement the core functionality
- [x] Add/update tests
- [x] Add/update documentation and inline comments
