### PR TITLE
fix(wallet): support legacy sequencer_addr top-level field in WalletConfig

### DIFF
--- a/lez/wallet/src/config.rs
+++ b/lez/wallet/src/config.rs
@@ -58,6 +58,9 @@ impl Default for MultiSequencerClientConfig {
 #[optfield::optfield(pub WalletConfigOverrides, rewrap, attrs = (derive(Debug, Default, Clone)))]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WalletConfig {
+    /// Legacy top-level sequencer address for backward compatibility.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sequencer_addr: Option<Url>,
     /// Connection data of all known sequencers.
     pub sequencers: Vec<SequencerConnectionData>,
     /// Sequencer polling duration for new blocks.
@@ -76,6 +79,7 @@ pub struct WalletConfig {
 impl Default for WalletConfig {
     fn default() -> Self {
         Self {
+            sequencer_addr: None,
             sequencers: vec![SequencerConnectionData {
                 sequencer_addr: "https://testnet.lez.logos.co".parse().unwrap(),
                 basic_auth: None,
@@ -94,7 +98,16 @@ impl WalletConfig {
         match std::fs::File::open(config_path) {
             Ok(file) => {
                 let reader = std::io::BufReader::new(file);
-                Ok(serde_json::from_reader(reader)?)
+                let mut config: WalletConfig = serde_json::from_reader(reader)?;
+                if config.sequencers.is_empty() {
+                    if let Some(ref addr) = config.sequencer_addr {
+                        config.sequencers.push(SequencerConnectionData {
+                            sequencer_addr: addr.clone(),
+                            basic_auth: None,
+                        });
+                    }
+                }
+                Ok(config)
             }
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
                 println!("Config not found, setting up default config");


### PR DESCRIPTION
## Summary
Fixes a deserialization mismatch where downstream tools (e.g. `spel` CLI) expecting legacy `sequencer_addr` top-level key fail when reading `wallet_config.json` generated by recent `wallet` builds.

## Changes
- Added optional `sequencer_addr` field to `WalletConfig` with `#[serde(default, skip_serializing_if = "Option::is_none")]`.
- Implemented fallback logic in `WalletConfig::from_path_or_initialize_default` to populate `sequencers` if legacy `sequencer_addr` is present.

## Testing
- Verified `WalletConfig` successfully deserializes both legacy single `sequencer_addr` and multi-`sequencers` JSON configs.