### PR TITLE
chore(lee,lez): fix pre-existing rustfmt violations on marvin/incremental-updates-2

### DIFF
--- a/examples/program_deployment/methods/guest/src/bin/hello_world.rs
+++ b/examples/program_deployment/methods/guest/src/bin/hello_world.rs
@@ -1,6 +1,9 @@
 use lee_core::{
     account::{Account, AccountDiff, BalanceDiff, Data},
-    program::{AccountDiffOutput, Claim, ProgramCall, ProgramInput, ProgramOutput, read_lee_call, write_update_from_diff_output},
+    program::{
+        AccountDiffOutput, Claim, ProgramCall, ProgramInput, ProgramOutput, read_lee_call,
+        write_update_from_diff_output,
+    },
 };
 
 // Hello-world example program.
@@ -82,6 +85,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }

--- a/examples/program_deployment/methods/guest/src/bin/hello_world_with_authorization.rs
+++ b/examples/program_deployment/methods/guest/src/bin/hello_world_with_authorization.rs
@@ -1,6 +1,9 @@
 use lee_core::{
     account::{Account, AccountDiff, BalanceDiff, Data},
-    program::{AccountDiffOutput, Claim, ProgramCall, ProgramInput, ProgramOutput, read_lee_call, write_update_from_diff_output},
+    program::{
+        AccountDiffOutput, Claim, ProgramCall, ProgramInput, ProgramOutput, read_lee_call,
+        write_update_from_diff_output,
+    },
 };
 
 // Hello-world with authorization example program.
@@ -89,6 +92,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }

--- a/examples/program_deployment/methods/guest/src/bin/hello_world_with_move_function.rs
+++ b/examples/program_deployment/methods/guest/src/bin/hello_world_with_move_function.rs
@@ -48,10 +48,7 @@ fn write(pre_state: AccountWithMetadata, greeting: &[u8]) -> AccountDiffOutput {
     )
 }
 
-fn move_data(
-    from_pre: AccountWithMetadata,
-    to_pre: AccountWithMetadata,
-) -> Vec<AccountDiffOutput> {
+fn move_data(from_pre: AccountWithMetadata, to_pre: AccountWithMetadata) -> Vec<AccountDiffOutput> {
     // Construct the post state account values
     let from_data: Vec<u8> = from_pre.account.data.clone().into();
 
@@ -68,7 +65,9 @@ fn move_data(
     let to_post = {
         let mut bytes = to_pre.account.data.clone().into_inner();
         bytes.extend_from_slice(&from_data);
-        let bytes: Data = bytes.try_into().expect("moved data fits under DATA_MAX_LENGTH");
+        let bytes: Data = bytes
+            .try_into()
+            .expect("moved data fits under DATA_MAX_LENGTH");
         AccountDiffOutput::new_claimed_if_default(
             AccountDiff {
                 id: to_pre.account_id,
@@ -129,6 +128,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }

--- a/lee/privacy_preserving_circuit/src/execution_state.rs
+++ b/lee/privacy_preserving_circuit/src/execution_state.rs
@@ -398,9 +398,9 @@ impl ExecutionState {
                 };
                 let journal_words =
                     to_vec(&expected_output).expect("UpdateFromDiffOutput must be serializable");
-                env::verify(program_id, &journal_words).unwrap_or_else(
-                    |_: Infallible| unreachable!("Infallible error is never constructed"),
-                );
+                env::verify(program_id, &journal_words).unwrap_or_else(|_: Infallible| {
+                    unreachable!("Infallible error is never constructed")
+                });
                 data
             } else {
                 pre_account.data.clone()
@@ -414,8 +414,7 @@ impl ExecutionState {
             if let Some(claim) = diff_output.required_claim() {
                 // The invoked program can only claim accounts with default program id.
                 assert_eq!(
-                    pre_account.program_owner,
-                    DEFAULT_PROGRAM_ID,
+                    pre_account.program_owner, DEFAULT_PROGRAM_ID,
                     "Cannot claim an initialized account {pre_account_id}"
                 );
 

--- a/lee/state_machine/core/src/program/mod.rs
+++ b/lee/state_machine/core/src/program/mod.rs
@@ -687,10 +687,7 @@ pub enum CallKind {
 /// The latter goes via that program's own `update_from_diff`.
 pub enum ProgramCall<T> {
     Execute(ProgramInput<T>, InstructionData),
-    UpdateFromDiff {
-        pre_state: Account,
-        diff_data: Data,
-    },
+    UpdateFromDiff { pre_state: Account, diff_data: Data },
 }
 
 /// Journal committed by an `UpdateFromDiff` invocation.
@@ -844,23 +841,27 @@ pub fn validate_execution(
         }
     }
 
-    // 5. Total balance is preserved: within this call's own diffs, every decrease must be
-    //    balanced by an equal increase.
-    let Some(total_added) = WrappedBalanceSum::from_balances(post_diff.iter().filter_map(
-        |diff_output| match diff_output.diff().diff_balance {
-            BalanceDiff::Add(amount) => Some(amount),
-            BalanceDiff::Sub(_) => None,
-        },
-    )) else {
+    // 5. Total balance is preserved: within this call's own diffs, every decrease must be balanced
+    //    by an equal increase.
+    let Some(total_added) =
+        WrappedBalanceSum::from_balances(post_diff.iter().filter_map(|diff_output| {
+            match diff_output.diff().diff_balance {
+                BalanceDiff::Add(amount) => Some(amount),
+                BalanceDiff::Sub(_) => None,
+            }
+        }))
+    else {
         return Err(ExecutionValidationError::BalanceSumOverflow);
     };
 
-    let Some(total_subbed) = WrappedBalanceSum::from_balances(post_diff.iter().filter_map(
-        |diff_output| match diff_output.diff().diff_balance {
-            BalanceDiff::Sub(amount) => Some(amount),
-            BalanceDiff::Add(_) => None,
-        },
-    )) else {
+    let Some(total_subbed) =
+        WrappedBalanceSum::from_balances(post_diff.iter().filter_map(|diff_output| {
+            match diff_output.diff().diff_balance {
+                BalanceDiff::Sub(amount) => Some(amount),
+                BalanceDiff::Add(_) => None,
+            }
+        }))
+    else {
         return Err(ExecutionValidationError::BalanceSumOverflow);
     };
 

--- a/lee/state_machine/test_methods/guest/src/bin/changer_claimer.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/changer_claimer.rs
@@ -64,6 +64,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }

--- a/lee/state_machine/test_methods/guest/src/bin/data_changer.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/data_changer.rs
@@ -57,6 +57,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }

--- a/lee/state_machine/test_methods/guest/src/bin/malicious_launderer.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/malicious_launderer.rs
@@ -1,4 +1,6 @@
-use lee_core::program::{ChainedCall, ProgramCall, ProgramId, ProgramInput, ProgramOutput, read_lee_call};
+use lee_core::program::{
+    ChainedCall, ProgramCall, ProgramId, ProgramInput, ProgramOutput, read_lee_call,
+};
 
 /// Instruction: (`auth_transfer_id`, `amount`) — both primitive, safe for `risc0_zkvm::serde`.
 type Instruction = (ProgramId, u128);

--- a/lee/state_machine/test_methods/guest/src/bin/noop.rs
+++ b/lee/state_machine/test_methods/guest/src/bin/noop.rs
@@ -17,7 +17,9 @@ fn main() {
     ) = match read_lee_call::<Instruction>() {
         ProgramCall::Execute(input, instruction_words) => (input, instruction_words),
         ProgramCall::UpdateFromDiff { .. } => {
-            unreachable!("noop program never writes diff_data, so update_from_diff is never dispatched")
+            unreachable!(
+                "noop program never writes diff_data, so update_from_diff is never dispatched"
+            )
         }
     };
 

--- a/lez/programs/amm/src/lib.rs
+++ b/lez/programs/amm/src/lib.rs
@@ -7,10 +7,9 @@
     reason = "TODO: Fix later"
 )]
 
-pub use amm_core as core;
-
 use std::convert::Infallible;
 
+pub use amm_core as core;
 use lee_core::{
     account::{Account, AccountDiff, AccountId, BalanceDiff, Data},
     program::AccountDiffOutput,

--- a/lez/programs/amm/src/main.rs
+++ b/lez/programs/amm/src/main.rs
@@ -9,7 +9,9 @@
 use std::num::NonZero;
 
 use amm_core::Instruction;
-use lee_core::program::{ProgramCall, ProgramInput, ProgramOutput, read_lee_call, write_update_from_diff_output};
+use lee_core::program::{
+    ProgramCall, ProgramInput, ProgramOutput, read_lee_call, write_update_from_diff_output,
+};
 
 fn main() {
     let (

--- a/lez/programs/amm/src/tests.rs
+++ b/lez/programs/amm/src/tests.rs
@@ -30,8 +30,7 @@ fn expected_diff(pre: &AccountWithMetadata, expected_post: &Account) -> AccountD
     } else {
         BalanceDiff::Sub(pre.account.balance - expected_post.balance)
     };
-    let diff_data =
-        (expected_post.data != pre.account.data).then(|| expected_post.data.clone());
+    let diff_data = (expected_post.data != pre.account.data).then(|| expected_post.data.clone());
     AccountDiff {
         id: pre.account_id,
         diff_balance,
@@ -3020,7 +3019,13 @@ fn new_definition_lp_asymmetric_amounts() {
 
     // check the minted LP amount
     let pool_post = post_states[0].clone();
-    let pool_data: Data = pool_post.diff().diff_data.clone().unwrap().try_into().unwrap();
+    let pool_data: Data = pool_post
+        .diff()
+        .diff_data
+        .clone()
+        .unwrap()
+        .try_into()
+        .unwrap();
     let pool_def = PoolDefinition::try_from(&pool_data).unwrap();
     assert_eq!(
         pool_def.liquidity_pool_supply,
@@ -3053,7 +3058,13 @@ fn new_definition_lp_symmetric_amounts() {
     );
 
     let pool_post = post_states[0].clone();
-    let pool_data: Data = pool_post.diff().diff_data.clone().unwrap().try_into().unwrap();
+    let pool_data: Data = pool_post
+        .diff()
+        .diff_data
+        .clone()
+        .unwrap()
+        .try_into()
+        .unwrap();
     let pool_def = PoolDefinition::try_from(&pool_data).unwrap();
     assert_eq!(pool_def.liquidity_pool_supply, expected_lp);
 

--- a/lez/programs/associated_token_account/src/burn.rs
+++ b/lez/programs/associated_token_account/src/burn.rs
@@ -1,4 +1,7 @@
-use lee_core::{account::AccountWithMetadata, program::{AccountDiffOutput, ChainedCall, ProgramId}};
+use lee_core::{
+    account::AccountWithMetadata,
+    program::{AccountDiffOutput, ChainedCall, ProgramId},
+};
 use token_core::TokenHolding;
 
 pub fn burn_from_associated_token_account(

--- a/lez/programs/associated_token_account/src/lib.rs
+++ b/lez/programs/associated_token_account/src/lib.rs
@@ -1,7 +1,6 @@
 //! The Associated Token Account Program implementation.
 
 pub use associated_token_account_core as core;
-
 use lee_core::{
     account::{AccountDiff, AccountId, BalanceDiff},
     program::AccountDiffOutput,

--- a/lez/programs/associated_token_account/src/transfer.rs
+++ b/lez/programs/associated_token_account/src/transfer.rs
@@ -1,4 +1,7 @@
-use lee_core::{account::AccountWithMetadata, program::{AccountDiffOutput, ChainedCall, ProgramId}};
+use lee_core::{
+    account::AccountWithMetadata,
+    program::{AccountDiffOutput, ChainedCall, ProgramId},
+};
 use token_core::TokenHolding;
 
 pub fn transfer_from_associated_token_account(

--- a/lez/programs/bridge_lock/src/main.rs
+++ b/lez/programs/bridge_lock/src/main.rs
@@ -8,8 +8,8 @@ use cross_zone_outbox_core::Instruction as OutboxInstruction;
 use lee_core::{
     account::{Account, AccountDiff, AccountId, AccountWithMetadata, BalanceDiff, Data},
     program::{
-        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput,
-        ProgramOutput, read_lee_call, write_update_from_diff_output,
+        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput, ProgramOutput,
+        read_lee_call, write_update_from_diff_output,
     },
 };
 use wrapped_token_core::{Instruction as WrappedInstruction, MAX_MINT_AMOUNT};

--- a/lez/programs/cross_zone_inbox/src/main.rs
+++ b/lez/programs/cross_zone_inbox/src/main.rs
@@ -8,8 +8,8 @@ use cross_zone_inbox_core::{
 use lee_core::{
     account::{Account, AccountDiff, AccountWithMetadata, BalanceDiff, Data},
     program::{
-        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput,
-        ProgramOutput, read_lee_call, write_update_from_diff_output,
+        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput, ProgramOutput,
+        read_lee_call, write_update_from_diff_output,
     },
 };
 

--- a/lez/programs/ping_sender/src/main.rs
+++ b/lez/programs/ping_sender/src/main.rs
@@ -4,8 +4,8 @@ use cross_zone_outbox_core::Instruction as OutboxInstruction;
 use lee_core::{
     account::{Account, AccountDiff, AccountId, AccountWithMetadata, BalanceDiff, Data},
     program::{
-        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput,
-        ProgramOutput, read_lee_call, write_update_from_diff_output,
+        AccountDiffOutput, ChainedCall, Claim, ProgramCall, ProgramId, ProgramInput, ProgramOutput,
+        read_lee_call, write_update_from_diff_output,
     },
 };
 use ping_core::{

--- a/lez/programs/token/src/lib.rs
+++ b/lez/programs/token/src/lib.rs
@@ -3,7 +3,6 @@
 use std::convert::Infallible;
 
 use lee_core::account::{Account, Data};
-
 pub use token_core as core;
 
 pub mod burn;

--- a/lez/programs/token/src/tests.rs
+++ b/lez/programs/token/src/tests.rs
@@ -33,8 +33,7 @@ fn expected_diff(pre: &AccountWithMetadata, expected_post: &Account) -> AccountD
     } else {
         BalanceDiff::Sub(pre.account.balance - expected_post.balance)
     };
-    let diff_data =
-        (expected_post.data != pre.account.data).then(|| expected_post.data.clone());
+    let diff_data = (expected_post.data != pre.account.data).then(|| expected_post.data.clone());
     AccountDiff {
         id: pre.account_id,
         diff_balance,

--- a/test_programs/guest/src/bin/pinata_cooldown.rs
+++ b/test_programs/guest/src/bin/pinata_cooldown.rs
@@ -137,6 +137,9 @@ fn main() {
     .write();
 }
 
-fn update_from_diff(_pre_state: Account, diff_data: Data) -> Result<Data, std::convert::Infallible> {
+fn update_from_diff(
+    _pre_state: Account,
+    diff_data: Data,
+) -> Result<Data, std::convert::Infallible> {
     Ok(diff_data)
 }


### PR DESCRIPTION
## Purpose

`marvin/incremental-updates-2` isn't `cargo +nightly fmt --check` clean — mechanical drift since the last fmt pass, mostly unwrapped long import lists. No functional changes.

Splitting this out so `marvin/incremental-updates-3-v2` (the next PR in the incremental-updates stack) can rebase onto it and drop the unrelated formatting noise from its own diff.

## How to Test

`cargo +nightly fmt --check` passes; `cargo check --workspace --all-features --all-targets` unaffected.